### PR TITLE
Locations attribute is optional in request

### DIFF
--- a/.github/workflows/.trivyignore
+++ b/.github/workflows/.trivyignore
@@ -1,13 +1,23 @@
-# Date: Feb-28-2022
+# Date: Feb-28-2023
 # Package: Spring Web
+# Issue: "HttpInvokerServiceExporter readRemoteInvocation method untrusted java deserialization"
+# Severity: Critical
 # Notes: Upgrading this package will depreciate other security packages. We need to rethink our AAI
 # Status: User story in Jira (DD-273)
 CVE-2016-1000027
 
-# Date: Feb-28-2022
+# Date: Feb-28-2023
 # Package: Snakeyaml
+# Issue: "Denial of Service due to missing nested depth"
+# Severity: High
 # Solution: This package is managed by Spring. Upgrading major version of Spring may fix this issue, but will break other dependencies
 # Status: User story in Jira (DD-272)
 CVE-2022-25857
-CVE-2022-1471
 
+# Date: Apr-3-2023
+# Package: Snakeyaml
+# Issue: "Constructor Deserialization Remote Code Execution"
+# Severity: Critical
+# Solution: This package is managed by Spring. Upgrading major version of Spring may fix this issue, but will break other dependencies
+# Status: User story in Jira (DD-272)
+CVE-2022-1471

--- a/.github/workflows/.trivyignore
+++ b/.github/workflows/.trivyignore
@@ -9,3 +9,5 @@ CVE-2016-1000027
 # Solution: This package is managed by Spring. Upgrading major version of Spring may fix this issue, but will break other dependencies
 # Status: User story in Jira (DD-272)
 CVE-2022-25857
+CVE-2022-1471
+

--- a/src/main/java/eu/dissco/core/handlemanager/domain/requests/attributes/HandleRecordRequest.java
+++ b/src/main/java/eu/dissco/core/handlemanager/domain/requests/attributes/HandleRecordRequest.java
@@ -2,7 +2,6 @@ package eu.dissco.core.handlemanager.domain.requests.attributes;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
-import javax.validation.constraints.NotEmpty;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -23,9 +22,7 @@ public class HandleRecordRequest {
   @JsonProperty(required = true)
   @JsonPropertyDescription("PID for the Subtype of Digital Object.")
   private final String digitalObjectSubtypePid;
-  @JsonProperty(required = true)
   @JsonPropertyDescription("Array containing the locations of the object.")
-  @NotEmpty
   private final String[] locations;
 
 }

--- a/src/main/java/eu/dissco/core/handlemanager/service/HandleService.java
+++ b/src/main/java/eu/dissco/core/handlemanager/service/HandleService.java
@@ -224,7 +224,7 @@ public class HandleService {
     return new JsonApiWrapperWrite(dataNode);
   }
 
-  private byte[] setPhysicalId(String physicalIdentifer, PhysicalIdType physicalIdType,
+  private byte[] setPhysicalId(String physicalIdentifier, PhysicalIdType physicalIdType,
       String specimenHostPid)
       throws InvalidRequestException {
     if (physicalIdType.equals(PhysicalIdType.COMBINED)) {
@@ -232,10 +232,10 @@ public class HandleService {
         throw new InvalidRequestException("Missing specimen host ID.");
       }
       var hostIdArr = specimenHostPid.split("/");
-      return (physicalIdentifer + ":" + hostIdArr[hostIdArr.length - 1]).getBytes(
+      return (physicalIdentifier + ":" + hostIdArr[hostIdArr.length - 1]).getBytes(
           StandardCharsets.UTF_8);
     }
-    return physicalIdentifer.getBytes(StandardCharsets.UTF_8);
+    return physicalIdentifier.getBytes(StandardCharsets.UTF_8);
   }
 
   private <T extends DigitalSpecimenRequest> void verifyNoRegisteredSpecimens(List<T> requests)
@@ -344,7 +344,7 @@ public class HandleService {
       String recordType = data.get(NODE_TYPE).asText();
       recordTypes.put(new String(handle, StandardCharsets.UTF_8), recordType);
 
-      JsonNode validatedAttributes = setLocationFromJson(requestAttributes);
+      JsonNode validatedAttributes = setLocationFromJson(requestAttributes, new String(handle, StandardCharsets.UTF_8));
       var attributes = prepareUpdateAttributes(handle, validatedAttributes);
       attributesToUpdate.add(attributes);
     }
@@ -367,7 +367,7 @@ public class HandleService {
     return recordTypes.get(pid);
   }
 
-  private JsonNode setLocationFromJson(JsonNode request)
+  private JsonNode setLocationFromJson(JsonNode request, String handle)
       throws InvalidRequestException, PidServiceInternalError {
     var keys = getKeys(request);
     if (!keys.contains(LOC_REQ)) {
@@ -379,7 +379,7 @@ public class HandleService {
     if (locNode.isArray()) {
       try {
         String[] locArr = mapper.treeToValue(locNode, String[].class);
-        requestObjectNode.put(LOC, new String(setLocations(locArr), StandardCharsets.UTF_8));
+        requestObjectNode.put(LOC, new String(setLocations(locArr, handle), StandardCharsets.UTF_8));
         requestObjectNode.remove(LOC_REQ);
       } catch (IOException e) {
         throw new InvalidRequestException(
@@ -529,7 +529,7 @@ public class HandleService {
             digitalObjectSubtype.getBytes(StandardCharsets.UTF_8)));
 
     // 5: 10320/loc
-    byte[] loc = setLocations(request.getLocations());
+    byte[] loc = setLocations(request.getLocations(), new String(handle, StandardCharsets.UTF_8));
     handleRecord.add(new HandleAttribute(FIELD_IDX.get(LOC), handle, LOC, loc));
 
     // 6: Issue Date
@@ -671,7 +671,7 @@ public class HandleService {
     return dt.format(Instant.now());
   }
 
-  public byte[] setLocations(String[] objectLocations) throws PidServiceInternalError {
+  public byte[] setLocations(String[] userLocations, String handle) throws PidServiceInternalError {
 
     DocumentBuilder documentBuilder = null;
     try {
@@ -683,12 +683,14 @@ public class HandleService {
     var doc = documentBuilder.newDocument();
     var locations = doc.createElement(LOC_REQ);
     doc.appendChild(locations);
-    for (int i = 0; i < objectLocations.length; i++) {
+    String[] objectLocations = concatLocations(userLocations, handle);
 
+    for (int i = 0; i < objectLocations.length; i++) {
       var locs = doc.createElement("location");
       locs.setAttribute(NODE_ID, String.valueOf(i));
       locs.setAttribute("href", objectLocations[i]);
-      locs.setAttribute("weight", "0");
+      String weight = i < 1 ? "1" : "0";
+      locs.setAttribute("weight", weight);
       locations.appendChild(locs);
     }
     try {
@@ -697,6 +699,23 @@ public class HandleService {
       throw new PidServiceInternalError("An internal error has occurred parsing location data", e);
     }
   }
+
+  private String[] concatLocations(String[] userLocations, String handle){
+    ArrayList<String> objectLocations = new ArrayList<>();
+    objectLocations.addAll(List.of(defaultLocations(handle)));
+    if (userLocations != null){
+      objectLocations.addAll(List.of(userLocations));
+    }
+    return objectLocations.toArray(new String[0]);
+  }
+
+  private String[] defaultLocations(String handle){
+    String api = "https://sandbox.dissco.tech/api/v1/specimens/" + handle;
+    String ui = "https://sandbox.dissco.tech/ds/" + handle;
+    return new String[]{api, ui};
+  }
+
+
 
   private String documentToString(Document document) throws TransformerException {
     var transformer = tf.newTransformer();


### PR DESCRIPTION
Two locations are automatically generated based on the handle minted:

`https://sandbox.dissco.tech/api/v1/specimens/ + handle`
`https://sandbox.dissco.tech/ds/" + handle`

When creating a new handle record, users have the option to provide an array of additional locations. 

All weights are 0, except for the API location. (Weights are used if a machine is performing a random selection on which location to redirect to, and we want predictable behaviour). 

The api location has an id of 0, the ui has an id of 1, and additional locations are found at id 2+. 

Example Record: https://hdl.handle.net/20.5000.1025/2Q8-Z4P-AJX?noredirect

[Jira DD-365](https://naturalis.atlassian.net/browse/DD-365?atlOrigin=eyJpIjoiYjVhMzg0NzJmNWIzNDY5ZWFlNThkMDM2MzI2MjI2NjgiLCJwIjoiaiJ9)