### PR TITLE
Feature/better archiving

### DIFF
--- a/.github/workflows/.trivyignore
+++ b/.github/workflows/.trivyignore
@@ -1,0 +1,4 @@
+# Date: June 7, 2023
+# Issue: libcrypto3/libssl3 out of date. Alpine needs to fix this.
+# Solution: Wait for Alpine to fix. Github issue has been opened.
+CVE-2023-2650

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR application
 ARG JAR_FILE=target/*spring-boot.jar
 COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
-apk upgrade libssl3 libcrypto3
+RUN apk upgrade libssl3 libcrypto3
 FROM eclipse-temurin:17-alpine
 RUN adduser -D -u 1000 java
 WORKDIR application

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM eclipse-temurin:17-alpine as builder
+FROM eclipse-temurin:17-alpine AS builder
+RUN apk update && apk upgrade
 WORKDIR application
 ARG JAR_FILE=target/*spring-boot.jar
 COPY ${JAR_FILE} application.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM eclipse-temurin:17-alpine AS builder
-RUN apk update && apk upgrade
 WORKDIR application
 ARG JAR_FILE=target/*spring-boot.jar
 COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
+apk upgrade libssl3 libcrypto3
 FROM eclipse-temurin:17-alpine
 RUN adduser -D -u 1000 java
 WORKDIR application

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM eclipse-temurin:17-alpine AS builder
+RUN apk update && apk upgrade --no-cache
 WORKDIR application
 ARG JAR_FILE=target/*spring-boot.jar
 COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
-RUN apk upgrade libssl3 libcrypto3
 FROM eclipse-temurin:17-alpine
 RUN adduser -D -u 1000 java
 WORKDIR application

--- a/kubernetes.yaml
+++ b/kubernetes.yaml
@@ -21,12 +21,10 @@ spec:
           ports:
             - containerPort: 80
           env:
-            - name: keycloak.auth-server-url
-              value: https://login-demo.dissco.eu/auth
-            - name: keycloak.realm
-              value: dissco
-            - name: keycloak.resource
-              value: processing-service
+            - name: spring.security.oauth2.resourceserver.jwt.issuer-uri
+              value: https://login-demo.dissco.eu/auth/realms/dissco
+            - name: spring.security.oauth2.authorizationserver.endpoint.jwk-set-uri
+              value: ${spring.security.oauth2.resourceserver.jwt.issuer-uri}/protocol/openid-connect/certs
             - name: spring.datasource.url
               value: jdbc:postgresql://database-1.cbppwfnjypll.eu-west-2.rds.amazonaws.com/dissco
             - name: spring.datasource.username

--- a/pom.xml
+++ b/pom.xml
@@ -72,10 +72,6 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-actuator</artifactId>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,14 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-actuator</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-oauth2-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+    </dependency>
 
     <!--Database Dependencies -->
     <dependency>

--- a/src/main/java/eu/dissco/core/handlemanager/controller/HandleController.java
+++ b/src/main/java/eu/dissco/core/handlemanager/controller/HandleController.java
@@ -4,6 +4,7 @@ package eu.dissco.core.handlemanager.controller;
 import static eu.dissco.core.handlemanager.domain.PidRecords.NODE_ATTRIBUTES;
 import static eu.dissco.core.handlemanager.domain.PidRecords.NODE_DATA;
 import static eu.dissco.core.handlemanager.domain.PidRecords.NODE_ID;
+import static eu.dissco.core.handlemanager.domain.PidRecords.NODE_TYPE;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -159,7 +160,7 @@ public class HandleController {
       throws InvalidRequestException, UnprocessableEntityException, PidResolutionException, PidServiceInternalError, JsonProcessingException {
     for (var request: requests){
       schemaValidator.validatePostRequest(request);
-      if (!request.get(NODE_DATA).get(NODE_ATTRIBUTES).asText().equals(ObjectType.DIGITAL_SPECIMEN.toString())){
+      if (!request.get(NODE_DATA).get(NODE_TYPE).asText().equals(ObjectType.DIGITAL_SPECIMEN.toString())){
         throw new InvalidRequestException("Invalid type. Upsert endpoint only available for type DigitalSpecimen");
       }
     }

--- a/src/main/java/eu/dissco/core/handlemanager/controller/HandleController.java
+++ b/src/main/java/eu/dissco/core/handlemanager/controller/HandleController.java
@@ -1,19 +1,23 @@
 package eu.dissco.core.handlemanager.controller;
 
 
+import static eu.dissco.core.handlemanager.domain.PidRecords.NODE_ATTRIBUTES;
 import static eu.dissco.core.handlemanager.domain.PidRecords.NODE_DATA;
 import static eu.dissco.core.handlemanager.domain.PidRecords.NODE_ID;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import eu.dissco.core.handlemanager.domain.jsonapi.JsonApiWrapperRead;
 import eu.dissco.core.handlemanager.domain.jsonapi.JsonApiWrapperReadSingle;
 import eu.dissco.core.handlemanager.domain.jsonapi.JsonApiWrapperWrite;
+import eu.dissco.core.handlemanager.domain.requests.attributes.ObjectType;
 import eu.dissco.core.handlemanager.domain.requests.attributes.PhysicalIdType;
 import eu.dissco.core.handlemanager.domain.requests.validation.JsonSchemaValidator;
 import eu.dissco.core.handlemanager.exceptions.InvalidRequestException;
 import eu.dissco.core.handlemanager.exceptions.PidCreationException;
 import eu.dissco.core.handlemanager.exceptions.PidResolutionException;
 import eu.dissco.core.handlemanager.exceptions.PidServiceInternalError;
+import eu.dissco.core.handlemanager.exceptions.UnprocessableEntityException;
 import eu.dissco.core.handlemanager.service.HandleService;
 import io.swagger.v3.oas.annotations.Operation;
 import java.nio.charset.StandardCharsets;
@@ -146,6 +150,21 @@ public class HandleController {
     }
     return ResponseEntity.status(HttpStatus.OK).body(service.updateRecords(requests));
   }
+
+  // Upsert
+  @Operation(summary="Create a PID Record; if it already exists, update contents. DigitalSpecimens only.")
+  @PatchMapping(value="/upsert")
+  public ResponseEntity<JsonApiWrapperWrite> upsertRecord(List<JsonNode> requests)
+      throws InvalidRequestException, UnprocessableEntityException, PidResolutionException, PidServiceInternalError, JsonProcessingException {
+    for (var request: requests){
+      schemaValidator.validatePostRequest(request);
+      if (!request.get(NODE_DATA).get(NODE_ATTRIBUTES).asText().equals(ObjectType.DIGITAL_SPECIMEN.toString())){
+        throw new InvalidRequestException("Invalid type. Upsert endpoint only available for type DigitalSpecimen");
+      }
+    }
+    return ResponseEntity.ok(service.upsertDigitalSpecimens(requests));
+  }
+
 
   @Operation(summary ="Archive given record")
   @PutMapping(value = "/{prefix}/{suffix}")

--- a/src/main/java/eu/dissco/core/handlemanager/controller/HandleController.java
+++ b/src/main/java/eu/dissco/core/handlemanager/controller/HandleController.java
@@ -113,6 +113,7 @@ public class HandleController {
   @PostMapping(value = "/batch")
   public ResponseEntity<JsonApiWrapperWrite> createRecords(@RequestBody List<JsonNode> requests)
       throws PidResolutionException, PidServiceInternalError, InvalidRequestException, PidCreationException {
+    log.info("received batch request");
 
     for (JsonNode request : requests) {
       schemaValidator.validatePostRequest(request);

--- a/src/main/java/eu/dissco/core/handlemanager/service/HandleGeneratorService.java
+++ b/src/main/java/eu/dissco/core/handlemanager/service/HandleGeneratorService.java
@@ -41,7 +41,7 @@ public class HandleGeneratorService {
     return handleList;
   }
 
-  public Set<ByteBuffer> genHandleHash(int h) {
+  private Set<ByteBuffer> genHandleHash(int h) {
 
     /*
      * Generates a HashSet of minted handles of size h Calls the handlefactory
@@ -104,15 +104,15 @@ public class HandleGeneratorService {
     return new String(buf);
   }
 
-  public String newHandle() {
+  private String newHandle() {
     return PREFIX + newSuffix();
   }
 
-  public byte[] newHandleBytes() {
+  private byte[] newHandleBytes() {
     return newHandle().getBytes(StandardCharsets.UTF_8);
   }
 
-  public List<byte[]> newHandle(int numberOfHandles) { // Generates h number of handles
+  private List<byte[]> newHandle(int numberOfHandles) { // Generates h number of handles
     if (numberOfHandles < 1) {
       log.warn("Invalid number of handles to be generated");
       return new ArrayList<>();

--- a/src/main/java/eu/dissco/core/handlemanager/service/HandleService.java
+++ b/src/main/java/eu/dissco/core/handlemanager/service/HandleService.java
@@ -286,7 +286,6 @@ public class HandleService {
     }
   }
 
-
   public JsonApiWrapperWrite upsertDigitalSpecimens(List<JsonNode> requests)
       throws JsonProcessingException, UnprocessableEntityException, PidResolutionException, InvalidRequestException, PidServiceInternalError {
     ArrayList<DigitalSpecimenRequest> digitalSpecimenRequests = new ArrayList<>();
@@ -300,7 +299,7 @@ public class HandleService {
     var upsertAttributes = prepareUpsertAttributes(upsertRequests);
 
     var createRequests = getCreateRequests(upsertRequests, digitalSpecimenRequests);
-    var newHandles = hf.newHandle(createRequests.size());
+    var newHandles = hf.genHandleList(createRequests.size());
     var createAttributes = getCreateAttributes(createRequests, newHandles);
 
     var allRequests = Stream.concat(
@@ -333,6 +332,9 @@ public class HandleService {
       List<DigitalSpecimenRequest> requests, List<byte[]> physicalIds) {
     var registeredSpecimensHandleAttributes = new HashSet<>(
         handleRep.searchByPhysicalIdentifier(physicalIds));
+    if (registeredSpecimensHandleAttributes.isEmpty()){
+      return new ArrayList<>();
+    }
 
     return registeredSpecimensHandleAttributes
         .stream()
@@ -361,9 +363,10 @@ public class HandleService {
 
   private List<HandleAttribute> getCreateAttributes(List<DigitalSpecimenRequest> digitalSpecimenRequests, List<byte[]> newHandles)
       throws UnprocessableEntityException, PidResolutionException, InvalidRequestException, PidServiceInternalError {
+    var handles = new ArrayList<>(newHandles);
     List<HandleAttribute> handleAttributes = new ArrayList<>();
     for (var digitalSpecimenRequest : digitalSpecimenRequests){
-      handleAttributes.addAll(fdoRecordBuilder.prepareDigitalSpecimenRecordAttributes(digitalSpecimenRequest, newHandles.remove(0)));
+      handleAttributes.addAll(fdoRecordBuilder.prepareDigitalSpecimenRecordAttributes(digitalSpecimenRequest, handles.remove(0)));
     }
     return handleAttributes;
   }

--- a/src/test/java/eu/dissco/core/handlemanager/component/FdoRecordBuilderTest.java
+++ b/src/test/java/eu/dissco/core/handlemanager/component/FdoRecordBuilderTest.java
@@ -56,6 +56,8 @@ import static eu.dissco.core.handlemanager.testUtils.TestUtils.STRUCTURAL_TYPE_T
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.TRANSFORMER_FACTORY;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.genDigitalSpecimenBotanyRequestObject;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.genMediaRequestObject;
+import static eu.dissco.core.handlemanager.testUtils.TestUtils.genTombstoneRecordRequestAttributes;
+import static eu.dissco.core.handlemanager.testUtils.TestUtils.genTombstoneRequest;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.genUpdateRecordAttributesAltLoc;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.genUpdateRequestAltLoc;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.givenDigitalSpecimenRequestObjectNullOptionals;
@@ -358,6 +360,19 @@ class FdoRecordBuilderTest {
 
     // Then
     assertThat(response).isEqualTo(expected);
+  }
+
+  @Test
+  void testTombstoneAttributes() throws Exception{
+    // Given
+    var expected = genTombstoneRecordRequestAttributes(HANDLE.getBytes(StandardCharsets.UTF_8));
+
+    // When
+    var response = fdoRecordBuilder.prepareTombstoneAttributes(HANDLE.getBytes(), genTombstoneRequest());
+
+    // Then
+    assertThat(response).isEqualTo(expected);
+
   }
 
 

--- a/src/test/java/eu/dissco/core/handlemanager/component/FdoRecordBuilderTest.java
+++ b/src/test/java/eu/dissco/core/handlemanager/component/FdoRecordBuilderTest.java
@@ -372,10 +372,7 @@ class FdoRecordBuilderTest {
 
     // Then
     assertThat(response).isEqualTo(expected);
-
   }
-
-
 
   private DigitalSpecimenRequest givenDigitalSpecimenRequestObjectOptionalsInit()
       throws InvalidRequestException {

--- a/src/test/java/eu/dissco/core/handlemanager/controller/HandleControllerExceptionHandlerTest.java
+++ b/src/test/java/eu/dissco/core/handlemanager/controller/HandleControllerExceptionHandlerTest.java
@@ -69,7 +69,7 @@ class HandleControllerExceptionHandlerTest {
   }
 
   @Test
-  void testPidServiceInternalErrorWithCause() throws Exception {
+  void testPidServiceInternalErrorWithCause() {
     // Given
     var cause = new IOException(errorMessage);
     var expectedMessage = errorMessage + ". Cause: " + cause + "\n " + cause.getLocalizedMessage();

--- a/src/test/java/eu/dissco/core/handlemanager/controller/HandleControllerTest.java
+++ b/src/test/java/eu/dissco/core/handlemanager/controller/HandleControllerTest.java
@@ -104,6 +104,12 @@ class HandleControllerTest {
   }
 
   @Test
+  void testResolvePidBadPrefix(){
+    assertThrows(PidResolutionException.class, () ->
+        controller.resolvePid(SUFFIX, SUFFIX, new MockHttpServletRequest()));
+  }
+
+  @Test
   void testSearchByPhysicalId() throws Exception {
     // Given
 
@@ -464,6 +470,27 @@ class HandleControllerTest {
   }
 
   @Test
+  void testUpsert() throws Exception{
+    // Given
+    var request = genCreateRecordRequest(givenDigitalSpecimenRequestObjectNullOptionals(), RECORD_TYPE_DS);
+
+    // When
+    var response = controller.upsertRecord(List.of(request));
+
+    // Then
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+  }
+
+  @Test
+  void testUpsertBadType() {
+    // Given
+    var request = genCreateRecordRequest(givenDigitalSpecimenRequestObjectNullOptionals(), RECORD_TYPE_DS_BOTANY);
+
+    // Then
+    assertThrows(InvalidRequestException.class, () -> controller.upsertRecord(List.of(request)));
+  }
+
+  @Test
   void testArchiveRecord() throws Exception {
     // Given
 
@@ -480,6 +507,15 @@ class HandleControllerTest {
     // Then
     assertThat(responseReceived.getStatusCode()).isEqualTo(HttpStatus.OK);
     assertThat(responseReceived.getBody()).isEqualTo(responseExpected);
+  }
+
+  @Test
+  void testArchiveRecordBadHandle() {
+    // Given
+    var archiveRequest = givenArchiveRequest();
+
+    // When
+    assertThrows(InvalidRequestException.class, () -> controller.archiveRecord(PREFIX, "123", archiveRequest));
   }
 
   @Test

--- a/src/test/java/eu/dissco/core/handlemanager/controller/HandleControllerTest.java
+++ b/src/test/java/eu/dissco/core/handlemanager/controller/HandleControllerTest.java
@@ -84,25 +84,6 @@ class HandleControllerTest {
   }
 
   @Test
-  void testGetAllHandlesByPidStatus() throws Exception {
-    // Given
-    int pageSize = 10;
-    int pageNum = 1;
-    var pidStatus = PidStatus.TEST;
-    List<String> expectedHandles = Collections.nCopies(pageSize, HANDLE);
-
-    given(service.getHandlesPaged(pageNum, pageSize, pidStatus.getBytes())).willReturn(expectedHandles);
-
-    // When
-    ResponseEntity<List<String>> response = controller.getAllHandlesByPidStatus(pageNum, pageSize,
-        pidStatus);
-
-    // Then
-    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-    assertThat(expectedHandles).isEqualTo(response.getBody());
-  }
-
-  @Test
   void testResolveSingleHandle() throws Exception {
     // Given
     String path = SANDBOX_URI + PREFIX + "/" + SUFFIX;
@@ -197,19 +178,6 @@ class HandleControllerTest {
 
     // Then
     assertThat(e.getMessage()).contains(String.valueOf(maxHandles));
-  }
-
-  @Test
-  void testGetAllHandlesFailure() {
-    // Given
-    given(service.getHandlesPaged(1, 10)).willReturn(new ArrayList<>());
-
-    // When
-    var exception = assertThrowsExactly(PidResolutionException.class,
-        () -> controller.getAllHandlesByPidStatus(1, 10, PidStatus.ALL));
-
-    // Then
-    assertThat(exception).hasMessage("Unable to resolve pids");
   }
 
   // Single Handle Record Creation
@@ -424,14 +392,6 @@ class HandleControllerTest {
     // Then
     assertThat(responseReceived.getStatusCode()).isEqualTo(HttpStatus.CREATED);
     assertThat(responseReceived.getBody()).isEqualTo(responseExpected);
-  }
-
-  @Test
-  void testHello() {
-    //When
-    ResponseEntity<String> response = controller.hello();
-    // Then
-    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
   }
 
   private JsonNode givenJsonNode(String id, String type, JsonNode attributes) {

--- a/src/test/java/eu/dissco/core/handlemanager/service/HandleGeneratorServiceTest.java
+++ b/src/test/java/eu/dissco/core/handlemanager/service/HandleGeneratorServiceTest.java
@@ -33,19 +33,6 @@ class HandleGeneratorServiceTest {
   }
 
   @Test
-  void testNewHandle() {
-    // Given
-    String expectedHandle = "20.5000.1025/AAA-AAA-AAA";
-    given(random.nextInt(anyInt())).willReturn(0);
-
-    // When
-    String newHandle = hgService.newHandle();
-
-    // Then
-    assertThat(newHandle).isEqualTo(expectedHandle);
-  }
-
-  @Test
   void testSingleBatchGen() {
     String expectedHandle = "20.5000.1025/AAA-AAA-AAA";
     given(random.nextInt(anyInt())).willReturn(0);
@@ -125,7 +112,7 @@ class HandleGeneratorServiceTest {
     Random randomGen = new Random();
 
     // When
-    var tooFew = hgService.newHandle(-1);
+    var tooFew = hgService.genHandleList(-1);
 
     // Then
     assertThat(tooFew).isEmpty();

--- a/src/test/java/eu/dissco/core/handlemanager/service/HandleServiceTest.java
+++ b/src/test/java/eu/dissco/core/handlemanager/service/HandleServiceTest.java
@@ -520,7 +520,7 @@ class HandleServiceTest {
   }
 
   @Test
-  void testUpdateRecordInternalDuplicates() throws Exception {
+  void testUpdateRecordInternalDuplicates()  {
 
     // Given
     List<byte[]> handles = new ArrayList<>();
@@ -536,7 +536,7 @@ class HandleServiceTest {
   }
 
   @Test
-  void testUpdateRecordNonWritable() throws Exception {
+  void testUpdateRecordNonWritable() {
     // Given
 
     List<JsonNode> updateRequest = genUpdateRequestBatch(handles);

--- a/src/test/java/eu/dissco/core/handlemanager/service/ServiceUtilsTest.java
+++ b/src/test/java/eu/dissco/core/handlemanager/service/ServiceUtilsTest.java
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.Test;
     // Given
    var request = givenDigitalSpecimenRequestObjectNullOptionals();
    var suffix = request.getSpecimenHost().replace(ROR_DOMAIN,"");
-   var expected = (request.getPrimarySpecimenObjectId() + ":" + suffix).getBytes(StandardCharsets.UTF_8);
+   var expected = request.getPrimarySpecimenObjectId() + ":" + suffix;
 
    // When
    var result = setUniquePhysicalIdentifierId(request);
@@ -47,7 +47,7 @@ import org.junit.jupiter.api.Test;
   void testSetUniquePhysicalIdentifierCombined(){
    // Given
    var request = givenCetafTypeDSRecord();
-   var expected = request.getPrimarySpecimenObjectId().getBytes(StandardCharsets.UTF_8);
+   var expected = request.getPrimarySpecimenObjectId();
 
    // When
    var result = setUniquePhysicalIdentifierId(request);

--- a/src/test/java/eu/dissco/core/handlemanager/testUtils/TestUtils.java
+++ b/src/test/java/eu/dissco/core/handlemanager/testUtils/TestUtils.java
@@ -156,7 +156,7 @@ public class TestUtils {
   // Tombstone Record vals
   public final static String TOMBSTONE_TEXT_TESTVAL = "pid was deleted";
   // Pid Type Record vals
-  private final static String HANDLE_URI = "https://hdl.handle.net/";
+  public final static String HANDLE_URI = "https://hdl.handle.net/";
   public static final String PTR_PID = HANDLE_URI + PID_ISSUER_TESTVAL_OTHER;
   public final static String PTR_HANDLE_RECORD = genPtrHandleRecord(false);
   public final static String PTR_DOI_RECORD = genPtrHandleRecord(true);
@@ -556,7 +556,11 @@ public class TestUtils {
     );
   }
 
-  public static DigitalSpecimenRequest givenDigitalSpecimenRequestObjectNullOptionals() {
+  public static DigitalSpecimenRequest givenDigitalSpecimenRequestObjectNullOptionals(){
+    return givenDigitalSpecimenRequestObjectNullOptionals(PRIMARY_SPECIMEN_OBJECT_ID_TESTVAL);
+  }
+
+  public static DigitalSpecimenRequest givenDigitalSpecimenRequestObjectNullOptionals(String physicalId) {
     try {
       return new DigitalSpecimenRequest(
           FDO_PROFILE_TESTVAL,
@@ -569,7 +573,7 @@ public class TestUtils {
           PRIMARY_REFERENT_TYPE_TESTVAL,
           SPECIMEN_HOST_TESTVAL,
           SPECIMEN_HOST_NAME_TESTVAL,
-          PRIMARY_SPECIMEN_OBJECT_ID_TESTVAL,
+          physicalId,
           null,null, null, null, null, null, null, null, null, null, null,null, null, null, null
           );
     } catch (InvalidRequestException e) {

--- a/src/test/java/eu/dissco/core/handlemanager/testUtils/TestUtils.java
+++ b/src/test/java/eu/dissco/core/handlemanager/testUtils/TestUtils.java
@@ -200,7 +200,8 @@ public class TestUtils {
 
     List<HandleAttribute> fdoRecord = new ArrayList<>();
     var request = givenHandleRecordRequestObject();
-    byte[] loc = setLocations(request.getLocations(), new String(handle, StandardCharsets.UTF_8));
+    byte[] loc = setLocations(request.getLocations(), new String(handle, StandardCharsets.UTF_8),
+        true);
     fdoRecord.add(new HandleAttribute(FIELD_IDX.get(LOC), handle, LOC, loc));
 
     // 1: FDO Profile
@@ -269,10 +270,10 @@ public class TestUtils {
       throws Exception {
     List<HandleAttribute> attributes = genHandleRecordAttributes(handle);
 
-    byte[] locOriginal = setLocations(LOC_TESTVAL, new String(handle, StandardCharsets.UTF_8));
+    byte[] locOriginal = setLocations(LOC_TESTVAL, new String(handle, StandardCharsets.UTF_8), true);
     var locOriginalAttr = new HandleAttribute(FIELD_IDX.get(LOC), handle, LOC, locOriginal);
 
-    byte[] locAlt = setLocations(LOC_ALT_TESTVAL, new String(handle, StandardCharsets.UTF_8));
+    byte[] locAlt = setLocations(LOC_ALT_TESTVAL, new String(handle, StandardCharsets.UTF_8), true);
     var locAltAttr = new HandleAttribute(FIELD_IDX.get(LOC), handle, LOC, locAlt);
 
     attributes.set(attributes.indexOf(locOriginalAttr), locAltAttr);
@@ -281,28 +282,30 @@ public class TestUtils {
   }
 
   public static List<HandleAttribute> genTombstoneRecordFullAttributes(byte[] handle) throws Exception {
-    List<HandleAttribute> attributes = genHandleRecordAttributes(handle);
+    List<HandleAttribute> attributes = genTombstoneRecordRequestAttributes(handle);
     HandleAttribute oldPidStatus = new HandleAttribute(FIELD_IDX.get(PID_STATUS), handle,
         PID_STATUS, PID_STATUS_TESTVAL.getBytes(StandardCharsets.UTF_8));
+    attributes.addAll(genHandleRecordAttributes(handle));
     attributes.remove(oldPidStatus);
-    attributes.addAll(genTombstoneRecordRequestAttributes(handle));
-
+    attributes = new ArrayList<>(attributes.stream().filter(row -> row.index()!=FIELD_IDX.get(LOC)).toList());
+    attributes.add(givenLandingPageAttribute(handle));
     return attributes;
   }
 
   public static List<HandleAttribute> genUpdateRecordAttributesAltLoc(byte[] handle)
       throws ParserConfigurationException, TransformerException {
-    byte[] locAlt = setLocations(LOC_ALT_TESTVAL, new String(handle, StandardCharsets.UTF_8));
+    byte[] locAlt = setLocations(LOC_ALT_TESTVAL, new String(handle, StandardCharsets.UTF_8), true);
     return List.of(new HandleAttribute(FIELD_IDX.get(LOC), handle, LOC, locAlt));
   }
 
-  public static List<HandleAttribute> genTombstoneRecordRequestAttributes(byte[] handle) {
+  public static List<HandleAttribute> genTombstoneRecordRequestAttributes(byte[] handle) throws Exception{
     List<HandleAttribute> tombstoneAttributes = new ArrayList<>();
     tombstoneAttributes.add(
         new HandleAttribute(FIELD_IDX.get(TOMBSTONE_TEXT), handle, TOMBSTONE_TEXT,
             TOMBSTONE_TEXT_TESTVAL.getBytes(StandardCharsets.UTF_8)));
     tombstoneAttributes.add(new HandleAttribute(FIELD_IDX.get(PID_STATUS), handle, PID_STATUS,
         "ARCHIVED".getBytes(StandardCharsets.UTF_8)));
+    tombstoneAttributes.add(givenLandingPageAttribute(handle));
     return tombstoneAttributes;
   }
 
@@ -355,7 +358,7 @@ public class TestUtils {
     fdoRecord.add(
         new HandleAttribute(FIELD_IDX.get(PRIMARY_SPECIMEN_OBJECT_ID), handle,
             PRIMARY_SPECIMEN_OBJECT_ID,
-            primarySpecimenObjectId));
+            primarySpecimenObjectId.getBytes(StandardCharsets.UTF_8)));
 
     // 203: primarySpecimenObjectIdType
     fdoRecord.add(
@@ -837,7 +840,18 @@ public class TestUtils {
 
   // Other Functions
 
-  public static byte[] setLocations(String[] userLocations, String handle)
+  public static byte[] givenLandingPage(String handle) throws Exception{
+    var landingPage = new String[]{"Placeholder landing page"};
+    return setLocations(landingPage, handle, false);
+  }
+
+  public static HandleAttribute givenLandingPageAttribute(byte[] handle) throws Exception{
+    var data = givenLandingPage(new String(handle, StandardCharsets.UTF_8));
+    return new HandleAttribute(FIELD_IDX.get(LOC), handle, LOC, data);
+  }
+
+  public static byte[] setLocations(String[] userLocations, String handle,
+      boolean includeDefaultLocs)
       throws TransformerException, ParserConfigurationException {
     DOC_BUILDER_FACTORY.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
 
@@ -846,7 +860,7 @@ public class TestUtils {
     var doc = documentBuilder.newDocument();
     var locations = doc.createElement("locations");
     doc.appendChild(locations);
-    String[] objectLocations = concatLocations(userLocations, handle);
+    String[] objectLocations = includeDefaultLocs ?  concatLocations(userLocations, handle) : userLocations;
 
     for (int i = 0; i < objectLocations.length; i++) {
       var locs = doc.createElement("location");


### PR DESCRIPTION
Archive operation now brought in line with FDO specifications. An archived PID has attributes 0-39, 100-101, as outlined in the RFC document. 

The archive operation is conducted as follows:
1. Generate tombstone attributes to be posted (e.g. tombstoneText, pidStatus = "ARCHIVED", etc.)
2. post/update existing handle record with generated attributes. Increment version. 
3. Delete any rows outside tombstone range [0-39, 100-101]

Note that the 10320/loc is meant to point to a landing page. There is currently a placeholder value there. 
