### PR TITLE
Can create a MAS object

### DIFF
--- a/src/main/java/eu/dissco/core/handlemanager/component/FdoRecordBuilder.java
+++ b/src/main/java/eu/dissco/core/handlemanager/component/FdoRecordBuilder.java
@@ -69,6 +69,7 @@ import eu.dissco.core.handlemanager.domain.requests.objects.DigitalSpecimenBotan
 import eu.dissco.core.handlemanager.domain.requests.objects.DigitalSpecimenRequest;
 import eu.dissco.core.handlemanager.domain.requests.objects.DoiRecordRequest;
 import eu.dissco.core.handlemanager.domain.requests.objects.HandleRecordRequest;
+import eu.dissco.core.handlemanager.domain.requests.objects.MasRequest;
 import eu.dissco.core.handlemanager.domain.requests.objects.MappingRequest;
 import eu.dissco.core.handlemanager.domain.requests.objects.MediaObjectRequest;
 import eu.dissco.core.handlemanager.domain.requests.objects.OrganisationRequest;
@@ -321,6 +322,12 @@ public class FdoRecordBuilder {
     }
 
     return fdoRecord;
+  }
+
+  public List<HandleAttribute> prepareMasRecordAttributes(MasRequest request, byte[] handle, ObjectType type)
+      throws PidServiceInternalError, UnprocessableEntityException, PidResolutionException, InvalidRequestException {
+    return prepareHandleRecordAttributes(request, handle, type);
+
   }
 
   private void resolveInternalPid(AnnotationRequest request) throws PidResolutionException {

--- a/src/main/java/eu/dissco/core/handlemanager/domain/requests/objects/MasRequest.java
+++ b/src/main/java/eu/dissco/core/handlemanager/domain/requests/objects/MasRequest.java
@@ -1,0 +1,16 @@
+package eu.dissco.core.handlemanager.domain.requests.objects;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+@EqualsAndHashCode(callSuper = true)
+public class MasRequest extends HandleRecordRequest {
+
+  public MasRequest(String fdoProfile, String issuedForAgent,
+      String digitalObjectType, String pidIssuer, String structuralType, String[] locations) {
+    super(fdoProfile, issuedForAgent, digitalObjectType, pidIssuer, structuralType, locations);
+  }
+}

--- a/src/main/java/eu/dissco/core/handlemanager/domain/requests/vocabulary/ObjectType.java
+++ b/src/main/java/eu/dissco/core/handlemanager/domain/requests/vocabulary/ObjectType.java
@@ -12,7 +12,8 @@ public enum ObjectType {
   @JsonProperty("sourceSystem") SOURCE_SYSTEM("sourceSystem"),
   @JsonProperty("mapping") MAPPING("mapping"),
   @JsonProperty("organisation") ORGANISATION("organisation"),
-  @JsonProperty("tombstone") TOMBSTONE("tombstone");
+  @JsonProperty("tombstone") TOMBSTONE("tombstone"),
+  @JsonProperty("machineAnnotationService") MAS("machineAnnotationService");
 
   private final String state;
 

--- a/src/main/java/eu/dissco/core/handlemanager/service/HandleService.java
+++ b/src/main/java/eu/dissco/core/handlemanager/service/HandleService.java
@@ -25,6 +25,7 @@ import eu.dissco.core.handlemanager.domain.requests.objects.DigitalSpecimenBotan
 import eu.dissco.core.handlemanager.domain.requests.objects.DigitalSpecimenRequest;
 import eu.dissco.core.handlemanager.domain.requests.objects.DoiRecordRequest;
 import eu.dissco.core.handlemanager.domain.requests.objects.HandleRecordRequest;
+import eu.dissco.core.handlemanager.domain.requests.objects.MasRequest;
 import eu.dissco.core.handlemanager.domain.requests.objects.MappingRequest;
 import eu.dissco.core.handlemanager.domain.requests.objects.MediaObjectRequest;
 import eu.dissco.core.handlemanager.domain.requests.vocabulary.ObjectType;
@@ -282,6 +283,11 @@ public class HandleService {
                 OrganisationRequest.class);
             handleAttributes.addAll(
                 fdoRecordBuilder.prepareOrganisationAttributes(requestObject, handles.remove(0), type));
+          }
+          case MAS -> {
+            var requestObject = mapper.treeToValue(dataNode.get(NODE_ATTRIBUTES), MasRequest.class);
+            handleAttributes.addAll(
+                fdoRecordBuilder.prepareMasRecordAttributes(requestObject, handles.remove(0), type));
           }
           default -> throw new InvalidRequestException(INVALID_TYPE_ERROR + type);
         }

--- a/src/test/java/eu/dissco/core/handlemanager/component/FdoRecordBuilderTest.java
+++ b/src/test/java/eu/dissco/core/handlemanager/component/FdoRecordBuilderTest.java
@@ -63,6 +63,7 @@ import static eu.dissco.core.handlemanager.testUtils.TestUtils.genDigitalSpecime
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.genHandleRecordAttributes;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.givenAnnotationRequestObject;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.givenMappingRequestObject;
+import static eu.dissco.core.handlemanager.testUtils.TestUtils.givenMasRecordRequestObject;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.givenMediaRequestObject;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.genUpdateRecordAttributesAltLoc;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.genUpdateRequestAltLoc;
@@ -233,6 +234,20 @@ class FdoRecordBuilderTest {
     assertThat(result).hasSize(ANNOTATION_QTY);
     assertThat(hasCorrectElements(result, HANDLE_FIELDS)).isTrue();
     assertThat(hasCorrectElements(result, ANNOTATION_FIELDS)).isTrue();
+  }
+
+  @Test
+  void testPrepareMasRecordAttributes() throws Exception {
+    // Given
+    given(pidResolver.getObjectName(any())).willReturn("placeholder");
+    var request = givenMasRecordRequestObject();
+
+    // When
+    var result = fdoRecordBuilder.prepareMasRecordAttributes(request, handle, ObjectType.HANDLE);
+
+    // Then
+    assertThat(result).hasSize(HANDLE_QTY);
+    assertThat(hasCorrectElements(result, HANDLE_FIELDS)).isTrue();
   }
 
   @Test

--- a/src/test/java/eu/dissco/core/handlemanager/service/HandleServiceTest.java
+++ b/src/test/java/eu/dissco/core/handlemanager/service/HandleServiceTest.java
@@ -13,6 +13,7 @@ import static eu.dissco.core.handlemanager.testUtils.TestUtils.RECORD_TYPE_DS;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.RECORD_TYPE_DS_BOTANY;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.RECORD_TYPE_HANDLE;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.RECORD_TYPE_MAPPING;
+import static eu.dissco.core.handlemanager.testUtils.TestUtils.RECORD_TYPE_MAS;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.RECORD_TYPE_MEDIA;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.RECORD_TYPE_ORGANISATION;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.RECORD_TYPE_SOURCE_SYSTEM;
@@ -70,7 +71,6 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -354,6 +354,25 @@ class HandleServiceTest {
 
     given(hgService.genHandleList(1)).willReturn(new ArrayList<>(List.of(handle)));
     given(handleRep.resolveHandleAttributes(anyList())).willReturn(mediaObject);
+
+    // When
+    var responseReceived = service.createRecords(List.of(request));
+
+    // Then
+    assertThat(responseReceived).isEqualTo(responseExpected);
+  }
+
+  @Test
+  void testCreateMasRecord() throws Exception {
+    // Given
+    byte[] handle = handles.get(0);
+    var request = genCreateRecordRequest(givenHandleRecordRequestObject(), RECORD_TYPE_MAS);
+    var responseExpected = givenRecordResponseWrite(List.of(handle), RECORD_TYPE_MAS);
+    List<HandleAttribute> handleRecord = genHandleRecordAttributes(handle, ObjectType.MAS);
+
+    given(hgService.genHandleList(1)).willReturn(new ArrayList<>(List.of(handle)));
+    given(handleRep.resolveHandleAttributes(anyList())).willReturn(handleRecord);
+    given(fdoRecordBuilder.prepareMasRecordAttributes(any(), any(), eq(ObjectType.MAS))).willReturn(handleRecord);
 
     // When
     var responseReceived = service.createRecords(List.of(request));

--- a/src/test/java/eu/dissco/core/handlemanager/testUtils/TestUtils.java
+++ b/src/test/java/eu/dissco/core/handlemanager/testUtils/TestUtils.java
@@ -77,6 +77,7 @@ import eu.dissco.core.handlemanager.domain.requests.objects.DigitalSpecimenReque
 import eu.dissco.core.handlemanager.domain.requests.objects.DoiRecordRequest;
 import eu.dissco.core.handlemanager.domain.requests.objects.HandleRecordRequest;
 import eu.dissco.core.handlemanager.domain.requests.objects.MappingRequest;
+import eu.dissco.core.handlemanager.domain.requests.objects.MasRequest;
 import eu.dissco.core.handlemanager.domain.requests.objects.MediaObjectRequest;
 import eu.dissco.core.handlemanager.domain.requests.vocabulary.ObjectType;
 import eu.dissco.core.handlemanager.domain.requests.vocabulary.PhysicalIdType;
@@ -129,6 +130,7 @@ public class TestUtils {
   public static final String RECORD_TYPE_MAPPING = "mapping";
   public static final String RECORD_TYPE_ANNOTATION = "annotation";
   public static final String RECORD_TYPE_ORGANISATION = "organisation";
+  public static final String RECORD_TYPE_MAS = "machineAnnotationService";
 
   // Request Test Vals
   // Handles
@@ -751,6 +753,17 @@ public class TestUtils {
         PRIMARY_REFERENT_TYPE_TESTVAL,
         SPECIMEN_HOST_TESTVAL,
         PTR_TYPE_DOI
+    );
+  }
+
+  public static MasRequest givenMasRecordRequestObject() {
+    return new MasRequest(
+        FDO_PROFILE_TESTVAL,
+        ISSUED_FOR_AGENT_TESTVAL,
+        DIGITAL_OBJECT_TYPE_TESTVAL,
+        PID_ISSUER_TESTVAL_OTHER,
+        STRUCTURAL_TYPE_TESTVAL,
+        LOC_TESTVAL
     );
   }
 


### PR DESCRIPTION
Allows users to create PID records for MAS (Machine Annotation Service) Objects by setting "type" in the request to "machineAnnotationService"

NB: FDO Profile has not been set for MAS Objects; current implementation just uses Handle Kernel. 
