### PR TITLE
Align request values

### DIFF
--- a/src/main/java/eu/dissco/core/handlemanager/component/FdoRecordBuilder.java
+++ b/src/main/java/eu/dissco/core/handlemanager/component/FdoRecordBuilder.java
@@ -330,7 +330,7 @@ public class FdoRecordBuilder {
     var fdoRecord = prepareHandleRecordAttributes(request, handle, type);
 
     fdoRecord.add(new HandleAttribute(FIELD_IDX.get(MAS_NAME), handle, MAS_NAME,
-        String.valueOf(request.getMasName()).getBytes(
+        String.valueOf(request.getMachineAnnotationServiceName()).getBytes(
             StandardCharsets.UTF_8)));
 
     return fdoRecord;

--- a/src/main/java/eu/dissco/core/handlemanager/component/FdoRecordBuilder.java
+++ b/src/main/java/eu/dissco/core/handlemanager/component/FdoRecordBuilder.java
@@ -8,7 +8,6 @@ import static eu.dissco.core.handlemanager.domain.PidRecords.DIGITAL_OBJECT_TYPE
 import static eu.dissco.core.handlemanager.domain.PidRecords.FDO_PROFILE;
 import static eu.dissco.core.handlemanager.domain.PidRecords.FDO_RECORD_LICENSE;
 import static eu.dissco.core.handlemanager.domain.PidRecords.FIELD_IDX;
-import static eu.dissco.core.handlemanager.domain.PidRecords.HOST_INSTITUTION;
 import static eu.dissco.core.handlemanager.domain.PidRecords.HS_ADMIN;
 import static eu.dissco.core.handlemanager.domain.PidRecords.INFORMATION_ARTEFACT_TYPE;
 import static eu.dissco.core.handlemanager.domain.PidRecords.ISSUED_FOR_AGENT;
@@ -46,6 +45,7 @@ import static eu.dissco.core.handlemanager.domain.PidRecords.REFERENT_NAME;
 import static eu.dissco.core.handlemanager.domain.PidRecords.REFERENT_TYPE;
 import static eu.dissco.core.handlemanager.domain.PidRecords.REPLACE_OR_APPEND;
 import static eu.dissco.core.handlemanager.domain.PidRecords.SOURCE_DATA_STANDARD;
+import static eu.dissco.core.handlemanager.domain.PidRecords.SOURCE_SYSTEM_NAME;
 import static eu.dissco.core.handlemanager.domain.PidRecords.SPECIMEN_HOST;
 import static eu.dissco.core.handlemanager.domain.PidRecords.SPECIMEN_HOST_NAME;
 import static eu.dissco.core.handlemanager.domain.PidRecords.STRUCTURAL_TYPE;
@@ -346,9 +346,9 @@ public class FdoRecordBuilder {
       throws UnprocessableEntityException, PidResolutionException, InvalidRequestException, PidServiceInternalError {
     var fdoRecord = prepareHandleRecordAttributes(request, handle, type);
 
-    // 600 hostInstitution
-    fdoRecord.add(new HandleAttribute(FIELD_IDX.get(HOST_INSTITUTION), handle,
-        HOST_INSTITUTION, request.getHostInstitution().getBytes(StandardCharsets.UTF_8)));
+    // 600 sourceSystemName
+    fdoRecord.add(new HandleAttribute(FIELD_IDX.get(SOURCE_SYSTEM_NAME), handle,
+        SOURCE_SYSTEM_NAME, request.getSourceSystemName().getBytes(StandardCharsets.UTF_8)));
 
     return fdoRecord;
   }

--- a/src/main/java/eu/dissco/core/handlemanager/component/FdoRecordBuilder.java
+++ b/src/main/java/eu/dissco/core/handlemanager/component/FdoRecordBuilder.java
@@ -17,6 +17,7 @@ import static eu.dissco.core.handlemanager.domain.PidRecords.LIVING_OR_PRESERVED
 import static eu.dissco.core.handlemanager.domain.PidRecords.LOC;
 import static eu.dissco.core.handlemanager.domain.PidRecords.LOC_REQ;
 import static eu.dissco.core.handlemanager.domain.PidRecords.MARKED_AS_TYPE;
+import static eu.dissco.core.handlemanager.domain.PidRecords.MAS_NAME;
 import static eu.dissco.core.handlemanager.domain.PidRecords.MATERIAL_OR_DIGITAL_ENTITY;
 import static eu.dissco.core.handlemanager.domain.PidRecords.MATERIAL_SAMPLE_TYPE;
 import static eu.dissco.core.handlemanager.domain.PidRecords.MEDIA_HASH;
@@ -326,8 +327,13 @@ public class FdoRecordBuilder {
 
   public List<HandleAttribute> prepareMasRecordAttributes(MasRequest request, byte[] handle, ObjectType type)
       throws PidServiceInternalError, UnprocessableEntityException, PidResolutionException, InvalidRequestException {
-    return prepareHandleRecordAttributes(request, handle, type);
+    var fdoRecord = prepareHandleRecordAttributes(request, handle, type);
 
+    fdoRecord.add(new HandleAttribute(FIELD_IDX.get(MAS_NAME), handle, MAS_NAME,
+        String.valueOf(request.getMasName()).getBytes(
+            StandardCharsets.UTF_8)));
+
+    return fdoRecord;
   }
 
   private void resolveInternalPid(AnnotationRequest request) throws PidResolutionException {

--- a/src/main/java/eu/dissco/core/handlemanager/domain/PidRecords.java
+++ b/src/main/java/eu/dissco/core/handlemanager/domain/PidRecords.java
@@ -74,6 +74,9 @@ public class PidRecords {
   // Mappings
   public static final String SOURCE_DATA_STANDARD = "sourceDataStandard";
 
+  // Machine Annotation Service
+  public static final String MAS_NAME = "machineAnnotationServiceName";
+
   // Organisations
   public static final String ORGANISATION_ID = "organisationIdentifier";
   public static final String ORGANISATION_ID_TYPE = "organisationIdentifierType";
@@ -124,6 +127,7 @@ public class PidRecords {
       Map.entry(SOURCE_SYSTEM_NAME, 600),
 
       Map.entry(SOURCE_DATA_STANDARD, 700),
+      Map.entry(MAS_NAME, 701),
 
       Map.entry(ORGANISATION_ID, 800),
       Map.entry(ORGANISATION_ID_TYPE, 801),

--- a/src/main/java/eu/dissco/core/handlemanager/domain/PidRecords.java
+++ b/src/main/java/eu/dissco/core/handlemanager/domain/PidRecords.java
@@ -1,15 +1,10 @@
 package eu.dissco.core.handlemanager.domain;
 
-import java.nio.charset.StandardCharsets;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 
 public class PidRecords {
 
   // Handle
-
   public static final String FDO_PROFILE = "fdoProfile"; // 1
   public static final String FDO_RECORD_LICENSE = "fdoRecordLicense"; //2
   public static final String DIGITAL_OBJECT_TYPE = "digitalObjectType"; //3
@@ -55,11 +50,9 @@ public class PidRecords {
   public static final String MARKED_AS_TYPE = "markedAsType"; // 216
   public static final String WAS_DERIVED_FROM = "wasDerivedFrom"; // 217
 
-
   // Handle Admin
   public static final String HS_ADMIN = "HS_ADMIN"; // 100
   public static final String LOC = "10320/loc"; //101
-
 
   // Media Object
   public static final String MEDIA_HASH = "mediaHash";
@@ -76,7 +69,7 @@ public class PidRecords {
   public static final String LINKED_URL = "linkedObjectUrl";
 
   // Source Systems
-  public static final String HOST_INSTITUTION = "hostInstitution";
+  public static final String SOURCE_SYSTEM_NAME = "sourceSystemName";
 
   // Mappings
   public static final String SOURCE_DATA_STANDARD = "sourceDataStandard";
@@ -87,29 +80,15 @@ public class PidRecords {
   public static final String ORGANISATION_NAME = "organisationName";
 
   // Fields for requests
-  public static final String PID_ISSUER_REQ = "pidIssuerPid";
   public static final String LOC_REQ = "locations";
-  public static final String REFERENT_DOI_NAME_REQ = "referentDoiNamePid";
-  public static final String SPECIMEN_HOST_REQ = "specimenHostPid";
-  public static final String IN_COLLECTION_FACILITY_REQ = "inCollectionFacilityPid";
   public static final String NODE_ATTRIBUTES = "attributes";
   public static final String NODE_DATA = "data";
   public static final String NODE_ID = "id";
   public static final String NODE_TYPE = "type";
 
-  // Permitted fields for each record type
-  public static final Set<String> HANDLE_RECORD_FIELDS = Set.of(PID, PID_ISSUER,
-      DIGITAL_OBJECT_TYPE, LOC, PID_RECORD_ISSUE_DATE,
-      PID_RECORD_ISSUE_NUMBER, PID_STATUS, FDO_RECORD_LICENSE);
-  public static final Set<byte[]> TOMBSTONE_RECORD_FIELDS_BYTES;
-  public static final Set<String> TOMBSTONE_RECORD_FIELDS;
-  // Fields for request type (For checking update requests)
-  public static final Set<String> HANDLE_RECORD_REQ = Set.of(PID_ISSUER_REQ, LOC_REQ);
-  public static final Set<String> DOI_RECORD_REQ;
-  public static final Set<String> DIGITAL_SPECIMEN_REQ;
-  public static final Set<String> DIGITAL_SPECIMEN_BOTANY_REQ;
 
-  public static final Map<String, Integer> FIELD_IDX = Map.ofEntries(Map.entry(FDO_PROFILE, 1),
+  public static final Map<String, Integer> FIELD_IDX = Map.<String, Integer>ofEntries(
+      Map.entry(FDO_PROFILE, 1),
       Map.entry(FDO_RECORD_LICENSE, 2), Map.entry(DIGITAL_OBJECT_TYPE, 3),
       Map.entry(DIGITAL_OBJECT_NAME, 4), Map.entry(PID, 5), Map.entry(PID_ISSUER, 6),
       Map.entry(PID_ISSUER_NAME, 7), Map.entry(ISSUED_FOR_AGENT, 8),
@@ -138,11 +117,11 @@ public class PidRecords {
       Map.entry(MEDIA_URL, 403),
       Map.entry(SUBJECT_PHYSICAL_IDENTIFIER, 404),
 
-      Map.entry(SUBJECT_DIGITAL_OBJECT_ID,500), Map.entry(ANNOTATION_TOPIC,501),
-      Map.entry(REPLACE_OR_APPEND,502), Map.entry(ACCESS_RESTRICTED,503),
-      Map.entry(LINKED_URL,504),
+      Map.entry(SUBJECT_DIGITAL_OBJECT_ID, 500), Map.entry(ANNOTATION_TOPIC, 501),
+      Map.entry(REPLACE_OR_APPEND, 502), Map.entry(ACCESS_RESTRICTED, 503),
+      Map.entry(LINKED_URL, 504),
 
-      Map.entry(HOST_INSTITUTION,600),
+      Map.entry(SOURCE_SYSTEM_NAME, 600),
 
       Map.entry(SOURCE_DATA_STANDARD, 700),
 
@@ -151,46 +130,6 @@ public class PidRecords {
       Map.entry(ORGANISATION_NAME, 802),
 
       Map.entry(HS_ADMIN, 100), Map.entry(LOC, 101));
-
-
-  static {
-    Set<String> tmp = new HashSet<>(HANDLE_RECORD_FIELDS);
-    tmp.add(TOMBSTONE_TEXT);
-    tmp.add(TOMBSTONE_PIDS);
-    TOMBSTONE_RECORD_FIELDS = Collections.unmodifiableSet(tmp);
-  }
-
-  static {
-    Set<byte[]> tmp = new HashSet<>();
-    for (String field : TOMBSTONE_RECORD_FIELDS) {
-      tmp.add(field.getBytes(StandardCharsets.UTF_8));
-    }
-    TOMBSTONE_RECORD_FIELDS_BYTES = Collections.unmodifiableSet(tmp);
-  }
-
-  // Request fields
-
-  static {
-    Set<String> tmp = new HashSet<>(HANDLE_RECORD_REQ);
-    tmp.add(REFERENT);
-    tmp.add(REFERENT_DOI_NAME_REQ);
-    DOI_RECORD_REQ = Collections.unmodifiableSet(tmp);
-  }
-
-  static {
-    Set<String> tmp = new HashSet<>(DOI_RECORD_REQ);
-    tmp.add(MATERIAL_OR_DIGITAL_ENTITY);
-    tmp.add(SPECIMEN_HOST_REQ);
-    tmp.add(IN_COLLECTION_FACILITY_REQ);
-    DIGITAL_SPECIMEN_REQ = Collections.unmodifiableSet(tmp);
-  }
-
-  static {
-    Set<String> tmp = new HashSet<>(DIGITAL_SPECIMEN_REQ);
-    tmp.add(OBJECT_TYPE);
-    tmp.add(LIVING_OR_PRESERVED);
-    DIGITAL_SPECIMEN_BOTANY_REQ = Collections.unmodifiableSet(tmp);
-  }
 
   private PidRecords() {
     throw new IllegalStateException("Utility class");

--- a/src/main/java/eu/dissco/core/handlemanager/domain/requests/objects/MasRequest.java
+++ b/src/main/java/eu/dissco/core/handlemanager/domain/requests/objects/MasRequest.java
@@ -8,9 +8,11 @@ import lombok.ToString;
 @ToString
 @EqualsAndHashCode(callSuper = true)
 public class MasRequest extends HandleRecordRequest {
+  private final String masName;
 
   public MasRequest(String fdoProfile, String issuedForAgent,
-      String digitalObjectType, String pidIssuer, String structuralType, String[] locations) {
+      String digitalObjectType, String pidIssuer, String structuralType, String[] locations, String masName) {
     super(fdoProfile, issuedForAgent, digitalObjectType, pidIssuer, structuralType, locations);
+    this.masName = masName;
   }
 }

--- a/src/main/java/eu/dissco/core/handlemanager/domain/requests/objects/MasRequest.java
+++ b/src/main/java/eu/dissco/core/handlemanager/domain/requests/objects/MasRequest.java
@@ -8,11 +8,11 @@ import lombok.ToString;
 @ToString
 @EqualsAndHashCode(callSuper = true)
 public class MasRequest extends HandleRecordRequest {
-  private final String masName;
+  private final String machineAnnotationServiceName;
 
   public MasRequest(String fdoProfile, String issuedForAgent,
       String digitalObjectType, String pidIssuer, String structuralType, String[] locations, String masName) {
     super(fdoProfile, issuedForAgent, digitalObjectType, pidIssuer, structuralType, locations);
-    this.masName = masName;
+    this.machineAnnotationServiceName = masName;
   }
 }

--- a/src/main/java/eu/dissco/core/handlemanager/domain/requests/objects/SourceSystemRequest.java
+++ b/src/main/java/eu/dissco/core/handlemanager/domain/requests/objects/SourceSystemRequest.java
@@ -10,10 +10,10 @@ import lombok.ToString;
 @EqualsAndHashCode(callSuper = true)
 public class SourceSystemRequest extends HandleRecordRequest {
   @JsonProperty(required = true)
-  private final String hostInstitution;
+  private final String sourceSystemName;
   public SourceSystemRequest(String fdoProfile, String issuedForAgent, String digitalObjectType,
-      String pidIssuer, String structuralType, String[] locations, String hostInstitution) {
+      String pidIssuer, String structuralType, String[] locations, String sourceSystemName) {
     super(fdoProfile, issuedForAgent, digitalObjectType, pidIssuer, structuralType, locations);
-    this.hostInstitution = hostInstitution;
+    this.sourceSystemName = sourceSystemName;
   }
 }

--- a/src/main/java/eu/dissco/core/handlemanager/domain/requests/validation/JsonSchemaValidator.java
+++ b/src/main/java/eu/dissco/core/handlemanager/domain/requests/validation/JsonSchemaValidator.java
@@ -26,6 +26,7 @@ import eu.dissco.core.handlemanager.domain.requests.objects.DigitalSpecimenReque
 import eu.dissco.core.handlemanager.domain.requests.objects.DoiRecordRequest;
 import eu.dissco.core.handlemanager.domain.requests.objects.HandleRecordRequest;
 import eu.dissco.core.handlemanager.domain.requests.objects.MappingRequest;
+import eu.dissco.core.handlemanager.domain.requests.objects.MasRequest;
 import eu.dissco.core.handlemanager.domain.requests.objects.MediaObjectRequest;
 import eu.dissco.core.handlemanager.domain.requests.vocabulary.ObjectType;
 import eu.dissco.core.handlemanager.domain.requests.vocabulary.TombstoneRecordRequest;
@@ -69,6 +70,8 @@ public class JsonSchemaValidator {
   private JsonNode sourceSystemPatchReqJsonNode;
   private JsonNode organisationPostReqJsonNode;
   private JsonNode organisationPatchReqJsonNode;
+  private JsonNode masPostReqJsonNode;
+  private JsonNode masPatchReqJsonNode;
 
   // Schemas
   private JsonSchema postReqSchema;
@@ -93,6 +96,8 @@ public class JsonSchemaValidator {
   private JsonSchema sourceSystemPatchReqSchema;
   private JsonSchema organisationPostReqSchema;
   private JsonSchema organisationPatchReqSchema;
+  private JsonSchema masPostReqSchema;
+  private JsonSchema masPatchReqSchema;
 
   public JsonSchemaValidator() {
     setPostRequestAttributesJsonNodes();
@@ -114,6 +119,7 @@ public class JsonSchemaValidator {
     mappingPostReqJsonNode = schemaGenerator.generateSchema(MappingRequest.class);
     sourceSystemPostReqJsonNode = schemaGenerator.generateSchema(SourceSystemRequest.class);
     organisationPostReqJsonNode = schemaGenerator.generateSchema(OrganisationRequest.class);
+    masPostReqJsonNode = schemaGenerator.generateSchema(MasRequest.class);
   }
 
   private SchemaGeneratorConfig jacksonModuleSchemaConfig() {
@@ -164,6 +170,7 @@ public class JsonSchemaValidator {
     mappingPatchReqJsonNode = schemaGenerator.generateSchema(MappingRequest.class);
     sourceSystemPatchReqJsonNode = schemaGenerator.generateSchema(SourceSystemRequest.class);
     organisationPatchReqJsonNode = schemaGenerator.generateSchema(OrganisationRequest.class);
+    masPatchReqJsonNode = schemaGenerator.generateSchema(MasRequest.class);
   }
 
   private SchemaGeneratorConfig attributesSchemaConfig() {
@@ -241,6 +248,7 @@ public class JsonSchemaValidator {
     mappingPostReqSchema = factory.getSchema(mappingPostReqJsonNode);
     sourceSystemPostReqSchema = factory.getSchema(sourceSystemPostReqJsonNode);
     organisationPostReqSchema = factory.getSchema(organisationPostReqJsonNode);
+    masPostReqSchema = factory.getSchema(masPostReqJsonNode);
 
     handlePatchReqSchema = factory.getSchema(handlePatchReqJsonNode);
     doiPatchReqSchema = factory.getSchema(doiPatchReqJsonNode);
@@ -251,6 +259,7 @@ public class JsonSchemaValidator {
     mappingPatchReqSchema = factory.getSchema(mappingPatchReqJsonNode);
     sourceSystemPatchReqSchema = factory.getSchema(sourceSystemPatchReqJsonNode);
     organisationPatchReqSchema = factory.getSchema(organisationPatchReqJsonNode);
+    masPatchReqSchema = factory.getSchema(masPatchReqJsonNode);
 
     tombstoneReqSchema = factory.getSchema(tombstoneReqJsonNode);
 
@@ -276,6 +285,7 @@ public class JsonSchemaValidator {
       case MAPPING -> validateRequestAttributes(attributes, mappingPostReqSchema, type);
       case SOURCE_SYSTEM -> validateRequestAttributes(attributes, sourceSystemPostReqSchema, type);
       case ORGANISATION -> validateRequestAttributes(attributes, organisationPostReqSchema, type);
+      case MAS -> validateRequestAttributes(attributes, masPostReqSchema, type);
       default ->
           throw new InvalidRequestException("Invalid Request. Reason: Invalid type: " + type);
     }
@@ -300,6 +310,7 @@ public class JsonSchemaValidator {
       case MAPPING -> validateRequestAttributes(attributes, mappingPatchReqSchema, type);
       case SOURCE_SYSTEM -> validateRequestAttributes(attributes, sourceSystemPatchReqSchema, type);
       case ORGANISATION -> validateRequestAttributes(attributes, organisationPatchReqSchema, type);
+      case MAS -> validateRequestAttributes(attributes, masPatchReqSchema, type);
       default ->
           throw new InvalidRequestException("Invalid Request. Reason: Invalid type: " + type);
     }

--- a/src/test/java/eu/dissco/core/handlemanager/component/FdoRecordBuilderTest.java
+++ b/src/test/java/eu/dissco/core/handlemanager/component/FdoRecordBuilderTest.java
@@ -16,6 +16,7 @@ import static eu.dissco.core.handlemanager.domain.PidRecords.LINKED_URL;
 import static eu.dissco.core.handlemanager.domain.PidRecords.LIVING_OR_PRESERVED;
 import static eu.dissco.core.handlemanager.domain.PidRecords.LOC;
 import static eu.dissco.core.handlemanager.domain.PidRecords.MARKED_AS_TYPE;
+import static eu.dissco.core.handlemanager.domain.PidRecords.MAS_NAME;
 import static eu.dissco.core.handlemanager.domain.PidRecords.MATERIAL_OR_DIGITAL_ENTITY;
 import static eu.dissco.core.handlemanager.domain.PidRecords.MATERIAL_SAMPLE_TYPE;
 import static eu.dissco.core.handlemanager.domain.PidRecords.OBJECT_TYPE;
@@ -246,8 +247,9 @@ class FdoRecordBuilderTest {
     var result = fdoRecordBuilder.prepareMasRecordAttributes(request, handle, ObjectType.HANDLE);
 
     // Then
-    assertThat(result).hasSize(HANDLE_QTY);
+    assertThat(result).hasSize(HANDLE_QTY+1);
     assertThat(hasCorrectElements(result, HANDLE_FIELDS)).isTrue();
+    assertThat(hasCorrectElements(result, Set.of(MAS_NAME))).isTrue();
   }
 
   @Test

--- a/src/test/java/eu/dissco/core/handlemanager/domain/JsonSchemaValidatorTest.java
+++ b/src/test/java/eu/dissco/core/handlemanager/domain/JsonSchemaValidatorTest.java
@@ -1,7 +1,6 @@
 package eu.dissco.core.handlemanager.domain;
 
 import static eu.dissco.core.handlemanager.domain.PidRecords.FDO_PROFILE;
-import static eu.dissco.core.handlemanager.domain.PidRecords.HOST_INSTITUTION;
 import static eu.dissco.core.handlemanager.domain.PidRecords.LIVING_OR_PRESERVED;
 import static eu.dissco.core.handlemanager.domain.PidRecords.MEDIA_URL;
 import static eu.dissco.core.handlemanager.domain.PidRecords.NODE_ATTRIBUTES;
@@ -13,9 +12,9 @@ import static eu.dissco.core.handlemanager.domain.PidRecords.PID_ISSUER;
 import static eu.dissco.core.handlemanager.domain.PidRecords.PRIMARY_SPECIMEN_OBJECT_ID_TYPE;
 import static eu.dissco.core.handlemanager.domain.PidRecords.REFERENT_NAME;
 import static eu.dissco.core.handlemanager.domain.PidRecords.SOURCE_DATA_STANDARD;
+import static eu.dissco.core.handlemanager.domain.PidRecords.SOURCE_SYSTEM_NAME;
 import static eu.dissco.core.handlemanager.domain.PidRecords.SPECIMEN_HOST;
 import static eu.dissco.core.handlemanager.domain.PidRecords.SUBJECT_DIGITAL_OBJECT_ID;
-import static eu.dissco.core.handlemanager.domain.PidRecords.SUBJECT_PHYSICAL_IDENTIFIER;
 import static eu.dissco.core.handlemanager.domain.PidRecords.TOMBSTONE_TEXT;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.HANDLE;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.LOC_TESTVAL;
@@ -33,7 +32,6 @@ import static eu.dissco.core.handlemanager.testUtils.TestUtils.RECORD_TYPE_ORGAN
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.RECORD_TYPE_SOURCE_SYSTEM;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.REFERENT_DOI_NAME_TESTVAL;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.SPECIMEN_HOST_TESTVAL;
-import static eu.dissco.core.handlemanager.testUtils.TestUtils.genAnnotationAttributes;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.genCreateRecordRequest;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.genDigitalSpecimenBotanyRequestObject;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.givenAnnotationRequestObject;
@@ -310,7 +308,7 @@ class JsonSchemaValidatorTest {
   @Test
   void testSourceSystemPatchRequest() {
     // Given
-    var request = givenUpdateRequest(RECORD_TYPE_SOURCE_SYSTEM, HOST_INSTITUTION, "new");
+    var request = givenUpdateRequest(RECORD_TYPE_SOURCE_SYSTEM, SOURCE_SYSTEM_NAME, "new");
 
     // Then
     assertDoesNotThrow(() -> {

--- a/src/test/java/eu/dissco/core/handlemanager/domain/JsonSchemaValidatorTest.java
+++ b/src/test/java/eu/dissco/core/handlemanager/domain/JsonSchemaValidatorTest.java
@@ -2,6 +2,7 @@ package eu.dissco.core.handlemanager.domain;
 
 import static eu.dissco.core.handlemanager.domain.PidRecords.FDO_PROFILE;
 import static eu.dissco.core.handlemanager.domain.PidRecords.LIVING_OR_PRESERVED;
+import static eu.dissco.core.handlemanager.domain.PidRecords.MAS_NAME;
 import static eu.dissco.core.handlemanager.domain.PidRecords.MEDIA_URL;
 import static eu.dissco.core.handlemanager.domain.PidRecords.NODE_ATTRIBUTES;
 import static eu.dissco.core.handlemanager.domain.PidRecords.NODE_DATA;
@@ -27,6 +28,7 @@ import static eu.dissco.core.handlemanager.testUtils.TestUtils.RECORD_TYPE_DS;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.RECORD_TYPE_DS_BOTANY;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.RECORD_TYPE_HANDLE;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.RECORD_TYPE_MAPPING;
+import static eu.dissco.core.handlemanager.testUtils.TestUtils.RECORD_TYPE_MAS;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.RECORD_TYPE_MEDIA;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.RECORD_TYPE_ORGANISATION;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.RECORD_TYPE_SOURCE_SYSTEM;
@@ -36,6 +38,7 @@ import static eu.dissco.core.handlemanager.testUtils.TestUtils.genCreateRecordRe
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.genDigitalSpecimenBotanyRequestObject;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.givenAnnotationRequestObject;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.givenMappingRequestObject;
+import static eu.dissco.core.handlemanager.testUtils.TestUtils.givenMasRecordRequestObject;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.givenMediaRequestObject;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.genTombstoneRequest;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.genTombstoneRequestBatch;
@@ -218,6 +221,17 @@ class JsonSchemaValidatorTest {
   }
 
   @Test
+  void testPostMasRequest() {
+    // Given
+    var request = genCreateRecordRequest(givenMasRecordRequestObject(), RECORD_TYPE_MAS);
+
+    // Then
+    assertDoesNotThrow(() -> {
+      schemaValidator.validatePostRequest(request);
+    });
+  }
+
+  @Test
   void testHandlePatchRequest() {
     // Given
     var request = givenUpdateRequest(RECORD_TYPE_HANDLE, PID_ISSUER, PID_ISSUER_TESTVAL_OTHER);
@@ -309,6 +323,17 @@ class JsonSchemaValidatorTest {
   void testSourceSystemPatchRequest() {
     // Given
     var request = givenUpdateRequest(RECORD_TYPE_SOURCE_SYSTEM, SOURCE_SYSTEM_NAME, "new");
+
+    // Then
+    assertDoesNotThrow(() -> {
+      schemaValidator.validatePatchRequest(request);
+    });
+  }
+
+  @Test
+  void testMasPatchRequest() {
+    // Given
+    var request = givenUpdateRequest(RECORD_TYPE_MAS, MAS_NAME, "new");
 
     // Then
     assertDoesNotThrow(() -> {

--- a/src/test/java/eu/dissco/core/handlemanager/testUtils/TestUtils.java
+++ b/src/test/java/eu/dissco/core/handlemanager/testUtils/TestUtils.java
@@ -8,7 +8,6 @@ import static eu.dissco.core.handlemanager.domain.PidRecords.DIGITAL_OBJECT_TYPE
 import static eu.dissco.core.handlemanager.domain.PidRecords.FDO_PROFILE;
 import static eu.dissco.core.handlemanager.domain.PidRecords.FDO_RECORD_LICENSE;
 import static eu.dissco.core.handlemanager.domain.PidRecords.FIELD_IDX;
-import static eu.dissco.core.handlemanager.domain.PidRecords.HOST_INSTITUTION;
 import static eu.dissco.core.handlemanager.domain.PidRecords.HS_ADMIN;
 import static eu.dissco.core.handlemanager.domain.PidRecords.INFORMATION_ARTEFACT_TYPE;
 import static eu.dissco.core.handlemanager.domain.PidRecords.ISSUED_FOR_AGENT;
@@ -47,9 +46,9 @@ import static eu.dissco.core.handlemanager.domain.PidRecords.REFERENT_NAME;
 import static eu.dissco.core.handlemanager.domain.PidRecords.REFERENT_TYPE;
 import static eu.dissco.core.handlemanager.domain.PidRecords.REPLACE_OR_APPEND;
 import static eu.dissco.core.handlemanager.domain.PidRecords.SOURCE_DATA_STANDARD;
+import static eu.dissco.core.handlemanager.domain.PidRecords.SOURCE_SYSTEM_NAME;
 import static eu.dissco.core.handlemanager.domain.PidRecords.SPECIMEN_HOST;
 import static eu.dissco.core.handlemanager.domain.PidRecords.SPECIMEN_HOST_NAME;
-import static eu.dissco.core.handlemanager.domain.PidRecords.SPECIMEN_HOST_REQ;
 import static eu.dissco.core.handlemanager.domain.PidRecords.STRUCTURAL_TYPE;
 import static eu.dissco.core.handlemanager.domain.PidRecords.SUBJECT_DIGITAL_OBJECT_ID;
 import static eu.dissco.core.handlemanager.domain.PidRecords.SUBJECT_PHYSICAL_IDENTIFIER;
@@ -571,8 +570,8 @@ public class TestUtils {
     var fdoRecord = genHandleRecordAttributes(handle, ObjectType.SOURCE_SYSTEM);
 
     // 600 hostInstitution
-    fdoRecord.add(new HandleAttribute(FIELD_IDX.get(HOST_INSTITUTION), handle,
-        HOST_INSTITUTION, SPECIMEN_HOST_TESTVAL.getBytes(StandardCharsets.UTF_8)));
+    fdoRecord.add(new HandleAttribute(FIELD_IDX.get(SOURCE_SYSTEM_NAME), handle,
+        SOURCE_SYSTEM_NAME, SPECIMEN_HOST_TESTVAL.getBytes(StandardCharsets.UTF_8)));
 
     return fdoRecord;
   }
@@ -780,7 +779,7 @@ public class TestUtils {
     var attributeNode = MAPPER.createObjectNode();
     attributeNode.set(PRIMARY_SPECIMEN_OBJECT_ID, MAPPER.valueToTree(
         PHYSICAL_IDENTIFIER_TESTVAL_CETAF));
-    attributeNode.put(SPECIMEN_HOST_REQ, SPECIMEN_HOST_TESTVAL);
+    attributeNode.put(SPECIMEN_HOST, SPECIMEN_HOST_TESTVAL);
     dataNode.set(NODE_ATTRIBUTES, attributeNode);
     request.set(NODE_DATA, dataNode);
     return request;

--- a/src/test/java/eu/dissco/core/handlemanager/testUtils/TestUtils.java
+++ b/src/test/java/eu/dissco/core/handlemanager/testUtils/TestUtils.java
@@ -157,7 +157,6 @@ public class TestUtils {
   //Digital Specimens
   public static final String SPECIMEN_HOST_TESTVAL = ROR_DOMAIN + "0x123";
   public static final String SPECIMEN_HOST_NAME_TESTVAL = "Naturalis";
-  public static final String IN_COLLECTION_FACILITY_TESTVAL = "20.5000.1025/OTHER-TRIPLET";
   // Annotations
   public static final String SUBJECT_DOI_TESTVAL = HANDLE_URI + "20.5000.1025/111";
   public static final String ANNOTATION_TOPIC_TESTVAL = "note";
@@ -170,6 +169,8 @@ public class TestUtils {
   public static final String MEDIA_HASH_ALG_TESTVAL = "SHA256";
   // Mappings
   public static final String SOURCE_DATA_STANDARD_TESTVAL = "dwc";
+  // MAS
+  public static final String MAS_NAME = "Plant Organ detection";
 
   public static final String API_URL = "https://sandbox.dissco.tech/api/v1";
   public static final String UI_URL = "https://sandbox.dissco.tech/";
@@ -762,7 +763,8 @@ public class TestUtils {
         DIGITAL_OBJECT_TYPE_TESTVAL,
         PID_ISSUER_TESTVAL_OTHER,
         STRUCTURAL_TYPE_TESTVAL,
-        LOC_TESTVAL
+        LOC_TESTVAL,
+        MAS_NAME
     );
   }
 


### PR DESCRIPTION
Change the PID records to align with what's being posted to the handle API by the orchestration service. 

Even if the FDO profiles for Source Systems, Mappings, and MASs aren't set, this is a better proof of concept for the orchestration service <-> handle api interaction. Now each object's pid record consists of the handle kernel plus one additional attribute:

- Mapping: sourceDataStandard
- SourceSystem: sourceSystemName
- MachineAnnotationService: machineAnnotationServiceName. 

Also cleaned up code a bit. 