### PR TITLE
bug fix: calculate expected physical ids

### DIFF
--- a/src/main/java/eu/dissco/core/handlemanager/component/FdoRecordComponent.java
+++ b/src/main/java/eu/dissco/core/handlemanager/component/FdoRecordComponent.java
@@ -22,6 +22,7 @@ import static eu.dissco.core.handlemanager.domain.FdoProfile.MATERIAL_SAMPLE_TYP
 import static eu.dissco.core.handlemanager.domain.FdoProfile.MEDIA_HOST;
 import static eu.dissco.core.handlemanager.domain.FdoProfile.MEDIA_OBJECT_TYPE;
 import static eu.dissco.core.handlemanager.domain.FdoProfile.MEDIA_URL;
+import static eu.dissco.core.handlemanager.domain.FdoProfile.NORMALISED_SPECIMEN_OBJECT_ID;
 import static eu.dissco.core.handlemanager.domain.FdoProfile.ORGANISATION_ID;
 import static eu.dissco.core.handlemanager.domain.FdoProfile.ORGANISATION_ID_TYPE;
 import static eu.dissco.core.handlemanager.domain.FdoProfile.ORGANISATION_NAME;
@@ -438,11 +439,10 @@ public class FdoRecordComponent {
     fdoRecord = setSpecimenHostName(request, fdoRecord, handle);
 
     // 202: primarySpecimenObjectId
-    var primarySpecimenObjectId = setUniquePhysicalIdentifierId(request);
     fdoRecord.add(
         new HandleAttribute(PRIMARY_SPECIMEN_OBJECT_ID.index(), handle,
             PRIMARY_SPECIMEN_OBJECT_ID.get(),
-            primarySpecimenObjectId.getBytes(StandardCharsets.UTF_8)));
+            request.getPrimarySpecimenObjectId().getBytes(StandardCharsets.UTF_8)));
 
     // 203: primarySpecimenObjectIdType
     fdoRecord.add(
@@ -461,6 +461,11 @@ public class FdoRecordComponent {
     }
 
     // 205 normalisedSpecimenObjectId
+    var normalisedPrimarySpecimenObjectId = setUniquePhysicalIdentifierId(request);
+    fdoRecord.add(
+        new HandleAttribute(NORMALISED_SPECIMEN_OBJECT_ID.index(), handle,
+            NORMALISED_SPECIMEN_OBJECT_ID.get(),
+            normalisedPrimarySpecimenObjectId.getBytes(StandardCharsets.UTF_8)));
 
     // 206: specimenObjectIdAbsenceReason
     if (request.getPrimarySpecimenObjectIdAbsenceReason() != null) {

--- a/src/main/java/eu/dissco/core/handlemanager/service/HandleService.java
+++ b/src/main/java/eu/dissco/core/handlemanager/service/HandleService.java
@@ -5,6 +5,7 @@ import static eu.dissco.core.handlemanager.domain.JsonApiFields.NODE_ATTRIBUTES;
 import static eu.dissco.core.handlemanager.domain.JsonApiFields.NODE_DATA;
 import static eu.dissco.core.handlemanager.domain.JsonApiFields.NODE_ID;
 import static eu.dissco.core.handlemanager.domain.JsonApiFields.NODE_TYPE;
+import static eu.dissco.core.handlemanager.service.ServiceUtils.setUniquePhysicalIdentifierId;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -417,7 +418,7 @@ public class HandleService {
   private DigitalSpecimenRequest getRequestFromPhysicalId(List<DigitalSpecimenRequest> requests,
       String physicalId) {
     for (var request: requests){
-      if (request.getPrimarySpecimenObjectId().equals(physicalId)){
+      if (setUniquePhysicalIdentifierId(request).equals(physicalId)){
         return request;
       }
     }

--- a/src/main/java/eu/dissco/core/handlemanager/service/HandleService.java
+++ b/src/main/java/eu/dissco/core/handlemanager/service/HandleService.java
@@ -162,7 +162,7 @@ public class HandleService {
       throws PidResolutionException, InvalidRequestException {
 
     var physicalIdentifier = setPhysicalId(physicalId, physicalIdType, specimenHostPid);
-    var returnedRows = handleRep.searchByPhysicalIdentifierFullRecord(List.of(physicalIdentifier));
+    var returnedRows = handleRep.searchByNormalisedPhysicalIdentifierFullRecord(List.of(physicalIdentifier));
     var handleNames = listHandleNamesReturnedFromQuery(returnedRows);
     if (handleNames.size() > 1) {
       throw new PidResolutionException(
@@ -313,7 +313,7 @@ public class HandleService {
 
   private void verifyNoRegisteredSpecimens(List<byte[]> physicalIds)
       throws PidCreationException {
-    var registeredSpecimens = handleRep.searchByPhysicalIdentifierFullRecord(physicalIds);
+    var registeredSpecimens = handleRep.searchByNormalisedPhysicalIdentifierFullRecord(physicalIds);
     if (!registeredSpecimens.isEmpty()) {
       var registeredHandles = listHandleNamesReturnedFromQuery(registeredSpecimens);
       throw new PidCreationException(
@@ -396,7 +396,7 @@ public class HandleService {
   private List<UpsertDigitalSpecimen> getRegisteredSpecimensUpsert(
       List<DigitalSpecimenRequest> requests, List<byte[]> physicalIds) {
     var registeredSpecimensHandleAttributes = new HashSet<>(
-        handleRep.searchByPhysicalIdentifier(physicalIds));
+        handleRep.searchByNormalisedPhysicalIdentifier(physicalIds));
     if (registeredSpecimensHandleAttributes.isEmpty()) {
       return new ArrayList<>();
     }

--- a/src/main/java/eu/dissco/core/handlemanager/service/HandleService.java
+++ b/src/main/java/eu/dissco/core/handlemanager/service/HandleService.java
@@ -335,6 +335,9 @@ public class HandleService {
 
     var createRequests = getCreateRequests(upsertRequests, digitalSpecimenRequests);
     var newHandles = hf.genHandleList(createRequests.size());
+    if (!newHandles.isEmpty()){
+      log.info("Successfully minted {} new handle(s)", newHandles.size());
+    }
     var createAttributes = getCreateAttributes(createRequests, newHandles);
 
     var allRequests = Stream.concat(
@@ -344,10 +347,10 @@ public class HandleService {
 
     var recordTimestamp = Instant.now().getEpochSecond();
 
-    log.info("Persisting update to db.");
-    handleRep.postAndUpdateHandles(recordTimestamp, createAttributes, upsertAttributes);  // O(n), 1xdb
+    log.info("Persisting upserts to db.");
+    handleRep.postAndUpdateHandles(recordTimestamp, createAttributes, upsertAttributes);
 
-    return concatAndFormatUpsertResponse(newHandles, upsertRequests); // O(n), 1x db
+    return concatAndFormatUpsertResponse(newHandles, upsertRequests);
   }
 
   private void logUpdates(List<UpsertDigitalSpecimen> upsertRequests){

--- a/src/test/java/eu/dissco/core/handlemanager/component/FdoRecordComponentTest.java
+++ b/src/test/java/eu/dissco/core/handlemanager/component/FdoRecordComponentTest.java
@@ -81,7 +81,7 @@ class FdoRecordComponentTest {
   private static final Set<String> DOI_FIELDS = Set.of(REFERENT_TYPE.get(), REFERENT_DOI_NAME.get(),
       REFERENT_NAME.get(), PRIMARY_REFERENT_TYPE.get());
   private static final Set<String> DS_FIELDS_MANDATORY = Set.of(SPECIMEN_HOST.get(), SPECIMEN_HOST_NAME.get(),
-      PRIMARY_SPECIMEN_OBJECT_ID.get(), PRIMARY_SPECIMEN_OBJECT_ID_TYPE.get(), MATERIAL_OR_DIGITAL_ENTITY.get());
+      PRIMARY_SPECIMEN_OBJECT_ID.get(), PRIMARY_SPECIMEN_OBJECT_ID_TYPE.get(), MATERIAL_OR_DIGITAL_ENTITY.get(), NORMALISED_SPECIMEN_OBJECT_ID.get());
 
   private static final Set<String> DS_FIELDS_OPTIONAL = Set.of(PRIMARY_SPECIMEN_OBJECT_ID_NAME.get(),
       OTHER_SPECIMEN_IDS.get(), TOPIC_ORIGIN.get(), TOPIC_DISCIPLINE.get(), LIVING_OR_PRESERVED.get(),
@@ -102,9 +102,9 @@ class FdoRecordComponentTest {
   private static final int HANDLE_QTY = 15;
   private static final int DOI_QTY = 19;
   private static final int MEDIA_QTY = 24;
-  private static final int DS_MANDATORY_QTY = 24;
-  private static final int DS_OPTIONAL_QTY = 35;
-  private static final int BOTANY_QTY = 24;
+  private static final int DS_MANDATORY_QTY = 25;
+  private static final int DS_OPTIONAL_QTY = 36;
+  private static final int BOTANY_QTY = 25;
   private static final int ANNOTATION_QTY = 21;
 
   @BeforeEach

--- a/src/test/java/eu/dissco/core/handlemanager/repository/HandleRepositoryIT.java
+++ b/src/test/java/eu/dissco/core/handlemanager/repository/HandleRepositoryIT.java
@@ -5,6 +5,7 @@ import static eu.dissco.core.handlemanager.domain.FdoProfile.*;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.CREATED;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.HANDLE;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.HANDLE_ALT;
+import static eu.dissco.core.handlemanager.testUtils.TestUtils.NORMALISED_PRIMARY_SPECIMEN_OBJECT_ID_TESTVAL;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.PID_STATUS_TESTVAL;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.PRIMARY_SPECIMEN_OBJECT_ID_TESTVAL;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.SPECIMEN_HOST_TESTVAL;
@@ -14,7 +15,6 @@ import static eu.dissco.core.handlemanager.testUtils.TestUtils.genHandleRecordAt
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.genHandleRecordAttributesAltLoc;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.genTombstoneRecordFullAttributes;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.genUpdateRecordAttributesAltLoc;
-import static eu.dissco.core.handlemanager.testUtils.TestUtils.givenDoiRecordRequestObject;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.jooq.impl.DSL.exp;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -248,23 +248,23 @@ class HandleRepositoryIT extends BaseRepositoryIT {
   @Test
   void testSearchByPhysicalIdentifierFullRecord(){
     // Given
-    var targetPhysicalIdentifer = PRIMARY_SPECIMEN_OBJECT_ID_TESTVAL.getBytes(StandardCharsets.UTF_8);
+    var targetPhysicalIdentifier = NORMALISED_PRIMARY_SPECIMEN_OBJECT_ID_TESTVAL.getBytes(StandardCharsets.UTF_8);
     List<HandleAttribute> responseExpected = new ArrayList<>();
     responseExpected.add(new HandleAttribute(1, HANDLE.getBytes(StandardCharsets.UTF_8),
-        PRIMARY_SPECIMEN_OBJECT_ID.get(), targetPhysicalIdentifer));
+        NORMALISED_SPECIMEN_OBJECT_ID.get(), targetPhysicalIdentifier));
     responseExpected.add(new HandleAttribute(2, HANDLE.getBytes(StandardCharsets.UTF_8), SPECIMEN_HOST.get(), SPECIMEN_HOST_TESTVAL.getBytes(
         StandardCharsets.UTF_8)));
 
     List<HandleAttribute> nonTargetAttributes = new ArrayList<>();
     nonTargetAttributes.add(new HandleAttribute(1, HANDLE_ALT.getBytes(StandardCharsets.UTF_8),
-        PRIMARY_SPECIMEN_OBJECT_ID.get(), "A".getBytes(
+        NORMALISED_SPECIMEN_OBJECT_ID.get(), "A".getBytes(
         StandardCharsets.UTF_8)));
 
     postAttributes(responseExpected);
     postAttributes(nonTargetAttributes);
 
     // When
-    var responseReceived = handleRep.searchByPhysicalIdentifierFullRecord(List.of(targetPhysicalIdentifer));
+    var responseReceived = handleRep.searchByNormalisedPhysicalIdentifierFullRecord(List.of(targetPhysicalIdentifier));
 
     // Then
     assertThat(responseReceived).hasSameElementsAs(responseExpected);
@@ -274,16 +274,16 @@ class HandleRepositoryIT extends BaseRepositoryIT {
   void testSearchByPhysicalSpecimenId() throws Exception {
     //Given
     var handle = HANDLE.getBytes(StandardCharsets.UTF_8);
-    var expected = List.of(new HandleAttribute(PRIMARY_SPECIMEN_OBJECT_ID.index(), handle,
-        PRIMARY_SPECIMEN_OBJECT_ID.get(),
-        PRIMARY_SPECIMEN_OBJECT_ID_TESTVAL.getBytes(StandardCharsets.UTF_8)));
+    var expected = List.of(new HandleAttribute(NORMALISED_SPECIMEN_OBJECT_ID.index(), handle,
+        NORMALISED_SPECIMEN_OBJECT_ID.get(),
+        NORMALISED_PRIMARY_SPECIMEN_OBJECT_ID_TESTVAL.getBytes(StandardCharsets.UTF_8)));
 
     postAttributes(genDoiRecordAttributes(handle, ObjectType.DOI));
     postAttributes(expected);
 
     // When
-    var response = handleRep.searchByPhysicalIdentifier(
-        List.of(PRIMARY_SPECIMEN_OBJECT_ID_TESTVAL.getBytes(StandardCharsets.UTF_8)));
+    var response = handleRep.searchByNormalisedPhysicalIdentifier(
+        List.of(NORMALISED_PRIMARY_SPECIMEN_OBJECT_ID_TESTVAL.getBytes(StandardCharsets.UTF_8)));
 
     // Then
     assertThat(response).isEqualTo(expected);

--- a/src/test/java/eu/dissco/core/handlemanager/service/HandleServiceTest.java
+++ b/src/test/java/eu/dissco/core/handlemanager/service/HandleServiceTest.java
@@ -19,6 +19,7 @@ import static eu.dissco.core.handlemanager.testUtils.TestUtils.RECORD_TYPE_MAS;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.RECORD_TYPE_MEDIA;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.RECORD_TYPE_ORGANISATION;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.RECORD_TYPE_SOURCE_SYSTEM;
+import static eu.dissco.core.handlemanager.testUtils.TestUtils.ROR_IDENTIFIER;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.SPECIMEN_HOST_TESTVAL;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.genAnnotationAttributes;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.genCreateRecordRequest;
@@ -776,20 +777,20 @@ class HandleServiceTest {
         genCreateRecordRequest(existingRecordRequest, RECORD_TYPE_DS));
 
     var existingRecordAttributes = genDigitalSpecimenAttributes(existingHandle);
-    var newRecordAttriutes = genDigitalSpecimenAttributes(newHandle);
+    var newRecordAttributes = genDigitalSpecimenAttributes(newHandle);
     var expected = new JsonApiWrapperWrite(
         List.of(upsertedResponse(existingRecordAttributes,
                 new String(existingHandle, StandardCharsets.UTF_8)),
-            upsertedResponse(newRecordAttriutes, new String(newHandle)))
+            upsertedResponse(newRecordAttributes, new String(newHandle)))
     );
 
     given(handleRep.searchByPhysicalIdentifier(anyList())).willReturn(
         List.of(new HandleAttribute(PRIMARY_SPECIMEN_OBJECT_ID.index(), existingHandle,
-            PRIMARY_SPECIMEN_OBJECT_ID_TYPE.get(), existingPhysId.getBytes(StandardCharsets.UTF_8))));
+            PRIMARY_SPECIMEN_OBJECT_ID_TYPE.get(), (existingPhysId+":"+ROR_IDENTIFIER).getBytes(StandardCharsets.UTF_8))));
     given(handleRep.resolveHandleAttributes(anyList())).willReturn(
-        Stream.concat(existingRecordAttributes.stream(), newRecordAttriutes.stream()).toList());
+        Stream.concat(existingRecordAttributes.stream(), newRecordAttributes.stream()).toList());
     given(fdoRecordComponent.prepareDigitalSpecimenRecordAttributes(eq(newRecordRequest), any(),
-        any())).willReturn(newRecordAttriutes);
+        any())).willReturn(newRecordAttributes);
     given(fdoRecordComponent.prepareUpdateAttributes(any(), eq(MAPPER.valueToTree(existingRecordRequest)), any())).willReturn(
         existingRecordAttributes);
     given(hgService.genHandleList(anyInt())).willReturn(new ArrayList<>(List.of(newHandle)));
@@ -800,7 +801,7 @@ class HandleServiceTest {
     // Then
     assertThat(response).isEqualTo(expected);
     then(handleRep).should()
-        .postAndUpdateHandles(CREATED.getEpochSecond(), newRecordAttriutes,
+        .postAndUpdateHandles(CREATED.getEpochSecond(), newRecordAttributes,
             List.of(existingRecordAttributes));
   }
 
@@ -835,7 +836,7 @@ class HandleServiceTest {
 
     given(handleRep.searchByPhysicalIdentifier(anyList())).willReturn(
         List.of(new HandleAttribute(PRIMARY_SPECIMEN_OBJECT_ID.index(), handles.get(0),
-            PRIMARY_SPECIMEN_OBJECT_ID.get(), PRIMARY_SPECIMEN_OBJECT_ID_TESTVAL.getBytes(
+            PRIMARY_SPECIMEN_OBJECT_ID.get(), (PRIMARY_SPECIMEN_OBJECT_ID_TESTVAL+":"+ROR_IDENTIFIER).getBytes(
             StandardCharsets.UTF_8))));
     given(handleRep.resolveHandleAttributes(anyList())).willReturn(existingRecord);
     given(fdoRecordComponent.prepareUpdateAttributes(any(), any(), any())).willReturn(

--- a/src/test/java/eu/dissco/core/handlemanager/service/HandleServiceTest.java
+++ b/src/test/java/eu/dissco/core/handlemanager/service/HandleServiceTest.java
@@ -180,7 +180,7 @@ class HandleServiceTest {
     var responseExpected = givenRecordResponseWriteGeneric(
         List.of(HANDLE.getBytes(StandardCharsets.UTF_8)), RECORD_TYPE_DS);
 
-    given(handleRep.searchByPhysicalIdentifierFullRecord(anyList()))
+    given(handleRep.searchByNormalisedPhysicalIdentifierFullRecord(anyList()))
         .willReturn(expectedAttributes);
 
     // When
@@ -203,7 +203,7 @@ class HandleServiceTest {
     var responseExpected = givenRecordResponseWriteGeneric(
         List.of(HANDLE.getBytes(StandardCharsets.UTF_8)), RECORD_TYPE_DS);
 
-    given(handleRep.searchByPhysicalIdentifierFullRecord(anyList()))
+    given(handleRep.searchByNormalisedPhysicalIdentifierFullRecord(anyList()))
         .willReturn(attributeList);
 
     // When
@@ -224,7 +224,7 @@ class HandleServiceTest {
     var responseExpected = givenRecordResponseWriteGeneric(
         List.of(HANDLE.getBytes(StandardCharsets.UTF_8)), RECORD_TYPE_DS);
 
-    given(handleRep.searchByPhysicalIdentifierFullRecord(anyList()))
+    given(handleRep.searchByNormalisedPhysicalIdentifierFullRecord(anyList()))
         .willReturn(expectedAttributes);
 
     // When
@@ -287,7 +287,7 @@ class HandleServiceTest {
 
     given(hgService.genHandleList(1)).willReturn(new ArrayList<>(List.of(handle)));
     given(handleRep.resolveHandleAttributes(anyList())).willReturn(digitalSpecimen);
-    given(handleRep.searchByPhysicalIdentifierFullRecord(anyList())).willReturn(new ArrayList<>());
+    given(handleRep.searchByNormalisedPhysicalIdentifierFullRecord(anyList())).willReturn(new ArrayList<>());
     given(fdoRecordComponent.prepareDigitalSpecimenRecordAttributes(any(), any(), any())).willReturn(
         digitalSpecimen);
 
@@ -307,7 +307,7 @@ class HandleServiceTest {
     List<HandleAttribute> digitalSpecimen = genDigitalSpecimenAttributes(handle);
 
     given(hgService.genHandleList(1)).willReturn(new ArrayList<>(List.of(handle)));
-    given(handleRep.searchByPhysicalIdentifierFullRecord(anyList())).willReturn(digitalSpecimen);
+    given(handleRep.searchByNormalisedPhysicalIdentifierFullRecord(anyList())).willReturn(digitalSpecimen);
 
     // When
     Exception e = assertThrows(PidCreationException.class, () -> {
@@ -331,7 +331,7 @@ class HandleServiceTest {
 
     given(hgService.genHandleList(1)).willReturn(new ArrayList<>(List.of(handle)));
     given(handleRep.resolveHandleAttributes(anyList())).willReturn(DigitalSpecimenBotany);
-    given(handleRep.searchByPhysicalIdentifierFullRecord(anyList())).willReturn(new ArrayList<>());
+    given(handleRep.searchByNormalisedPhysicalIdentifierFullRecord(anyList())).willReturn(new ArrayList<>());
 
     // When
     var responseReceived = service.createRecords(List.of(request));
@@ -349,7 +349,7 @@ class HandleServiceTest {
     List<HandleAttribute> digitalSpecimenBotany = genDigitalSpecimenBotanyAttributes(handle);
 
     given(hgService.genHandleList(1)).willReturn(new ArrayList<>(List.of(handle)));
-    given(handleRep.searchByPhysicalIdentifierFullRecord(anyList())).willReturn(
+    given(handleRep.searchByNormalisedPhysicalIdentifierFullRecord(anyList())).willReturn(
         digitalSpecimenBotany);
 
     // When
@@ -784,7 +784,7 @@ class HandleServiceTest {
             upsertedResponse(newRecordAttributes, new String(newHandle)))
     );
 
-    given(handleRep.searchByPhysicalIdentifier(anyList())).willReturn(
+    given(handleRep.searchByNormalisedPhysicalIdentifier(anyList())).willReturn(
         List.of(new HandleAttribute(PRIMARY_SPECIMEN_OBJECT_ID.index(), existingHandle,
             PRIMARY_SPECIMEN_OBJECT_ID_TYPE.get(), (existingPhysId+":"+ROR_IDENTIFIER).getBytes(StandardCharsets.UTF_8))));
     given(handleRep.resolveHandleAttributes(anyList())).willReturn(
@@ -834,7 +834,7 @@ class HandleServiceTest {
         List.of(upsertedResponse(existingRecord, HANDLE))
     );
 
-    given(handleRep.searchByPhysicalIdentifier(anyList())).willReturn(
+    given(handleRep.searchByNormalisedPhysicalIdentifier(anyList())).willReturn(
         List.of(new HandleAttribute(PRIMARY_SPECIMEN_OBJECT_ID.index(), handles.get(0),
             PRIMARY_SPECIMEN_OBJECT_ID.get(), (PRIMARY_SPECIMEN_OBJECT_ID_TESTVAL+":"+ROR_IDENTIFIER).getBytes(
             StandardCharsets.UTF_8))));
@@ -863,7 +863,7 @@ class HandleServiceTest {
         List.of(upsertedResponse(newRecord, HANDLE_ALT))
     );
 
-    given(handleRep.searchByPhysicalIdentifier(anyList())).willReturn(new ArrayList<>());
+    given(handleRep.searchByNormalisedPhysicalIdentifier(anyList())).willReturn(new ArrayList<>());
     given(handleRep.resolveHandleAttributes(anyList())).willReturn(newRecord);
     given(fdoRecordComponent.prepareDigitalSpecimenRecordAttributes(any(), any(), any())).willReturn(
         newRecord);

--- a/src/test/java/eu/dissco/core/handlemanager/testUtils/TestUtils.java
+++ b/src/test/java/eu/dissco/core/handlemanager/testUtils/TestUtils.java
@@ -125,6 +125,7 @@ public class TestUtils {
   public static final String ORCHESTRATION_URL = "https://orchestration.dissco.tech/api/v1";
   public static final String PTR_TYPE_DOI = "doi";
   public final static String PRIMARY_SPECIMEN_OBJECT_ID_TESTVAL = "BOTANICAL.QRS.123";
+  public final static String NORMALISED_PRIMARY_SPECIMEN_OBJECT_ID_TESTVAL = PRIMARY_SPECIMEN_OBJECT_ID_TESTVAL + ":" + ROR_IDENTIFIER;
   public final static PhysicalIdentifier PHYSICAL_IDENTIFIER_TESTVAL_CETAF = new PhysicalIdentifier(
       PRIMARY_SPECIMEN_OBJECT_ID_TESTVAL,
       PhysicalIdType.CETAF

--- a/src/test/java/eu/dissco/core/handlemanager/testUtils/TestUtils.java
+++ b/src/test/java/eu/dissco/core/handlemanager/testUtils/TestUtils.java
@@ -102,7 +102,8 @@ public class TestUtils {
   //DOIs
 
   //Digital Specimens
-  public static final String SPECIMEN_HOST_TESTVAL = ROR_DOMAIN + "0x123";
+  public static final String ROR_IDENTIFIER = "0x123";
+  public static final String SPECIMEN_HOST_TESTVAL = ROR_DOMAIN + ROR_IDENTIFIER;
   public static final String SPECIMEN_HOST_NAME_TESTVAL = "Naturalis";
   // Annotations
   public static final String SUBJECT_DOI_TESTVAL = HANDLE_URI + "20.5000.1025/111";


### PR DESCRIPTION
1. Program was comparing physical identifier in the request to a list of physical identifiers that were used to search the handle db for existing records. The latter was actually a list of normalized identifiers (i.e. with the organisation appended when necessary), so matching was not possible.
 
2. Introduced normalisedPrimaryObjectIdentifier as a separate field in the FDO (this change is in line with the RFC, further changes are on the backlog). Before, the PrimaryObjectIdentifier was the normalised value. The specimenProcessor takes the primaryObjectIdentifier from the handleAPI response and compares it with its list of DigitalSpecimenEvents to match newly minted handles with the correct event. If the response from the handleAPI is normalised, then there might not be a match. 

[See companion PR in the specimen processor. ](https://github.com/DiSSCo/dissco-core-digital-specimen-processor/pull/26)