### PR TITLE
Feature/smaller upsert responses

### DIFF
--- a/src/main/java/eu/dissco/core/handlemanager/repository/HandleRepository.java
+++ b/src/main/java/eu/dissco/core/handlemanager/repository/HandleRepository.java
@@ -71,6 +71,15 @@ public class HandleRepository {
         .fetch(this::mapToAttribute);
   }
 
+  public List<HandleAttribute> getPrimarySpecimenObjectId(List<byte[]> handles){
+    return context
+        .select(HANDLES.IDX, HANDLES.HANDLE, HANDLES.TYPE, HANDLES.DATA)
+        .from(HANDLES)
+        .where(HANDLES.HANDLE.in(handles))
+        .and(HANDLES.TYPE.eq(PRIMARY_SPECIMEN_OBJECT_ID.get().getBytes(StandardCharsets.UTF_8)))
+        .fetch(this::mapToAttribute);
+  }
+
   public List<HandleAttribute> searchByNormalisedPhysicalIdentifierFullRecord(
       List<byte[]> normalisedPhysicalIdentifiers) {
     var normalisedPhysicalIdentifierTable = searchByNormalisedPhysicalIdentifierQuery(

--- a/src/main/java/eu/dissco/core/handlemanager/service/HandleService.java
+++ b/src/main/java/eu/dissco/core/handlemanager/service/HandleService.java
@@ -360,13 +360,10 @@ public class HandleService {
   }
 
   private JsonApiWrapperWrite concatAndFormatUpsertResponse(List<HandleAttribute> records) {
-    Set<String> handles = new HashSet<>();
     List<JsonApiDataLinks> dataLinksList = new ArrayList<>();
     for (var row: records){
-      if (row.type().equals(PRIMARY_SPECIMEN_OBJECT_ID.get()) &&
-          !handles.contains(new String(row.handle(), StandardCharsets.UTF_8))){
+      if (row.type().equals(PRIMARY_SPECIMEN_OBJECT_ID.get())){
         String h = new String(row.handle(), StandardCharsets.UTF_8);
-        handles.add(h);
         String pidLink = "https://hdl.handle.net/" + h;
         var node = mapper.createObjectNode();
         node.put(PRIMARY_SPECIMEN_OBJECT_ID.get(), new String(row.data(), StandardCharsets.UTF_8));

--- a/src/test/java/eu/dissco/core/handlemanager/repository/HandleRepositoryIT.java
+++ b/src/test/java/eu/dissco/core/handlemanager/repository/HandleRepositoryIT.java
@@ -153,6 +153,28 @@ class HandleRepositoryIT extends BaseRepositoryIT {
   }
 
   @Test
+  void testGetPrimarySpecimenObjectIds() throws Exception {
+    // Given
+    var handle = HANDLE.getBytes(StandardCharsets.UTF_8);
+    var handleAlt = HANDLE_ALT.getBytes(StandardCharsets.UTF_8);
+    var postedAttributes = Stream.concat(
+        genHandleRecordAttributes(handle, ObjectType.DIGITAL_SPECIMEN).stream(),
+        genHandleRecordAttributes(handleAlt, ObjectType.DIGITAL_SPECIMEN).stream()).toList();
+    postAttributes(postedAttributes);
+    List<HandleAttribute> expected = new ArrayList<>();
+    for (var row : postedAttributes) {
+      if (row.type().equals(PRIMARY_SPECIMEN_OBJECT_ID.get())) {
+        expected.add(row);
+      }
+    }
+    // When
+    var result = handleRep.getPrimarySpecimenObjectId(List.of(handle, handleAlt));
+
+    // Then
+    assertThat(result).hasSameElementsAs(expected);
+  }
+
+  @Test
   void testResolveBatchRecord() throws Exception {
     // Given
     List<byte[]> handles = List.of(HANDLE.getBytes(StandardCharsets.UTF_8),
@@ -200,7 +222,7 @@ class HandleRepositoryIT extends BaseRepositoryIT {
     int pageNum = 2;
     int pageSize = 5;
 
-    List<String> handles = genListofHandlesString(pageSize+1);
+    List<String> handles = genListofHandlesString(pageSize + 1);
     List<HandleAttribute> rows = new ArrayList<>();
 
     for (String handle : handles) {
@@ -246,14 +268,17 @@ class HandleRepositoryIT extends BaseRepositoryIT {
   }
 
   @Test
-  void testSearchByPhysicalIdentifierFullRecord(){
+  void testSearchByPhysicalIdentifierFullRecord() {
     // Given
-    var targetPhysicalIdentifier = NORMALISED_PRIMARY_SPECIMEN_OBJECT_ID_TESTVAL.getBytes(StandardCharsets.UTF_8);
+    var targetPhysicalIdentifier = NORMALISED_PRIMARY_SPECIMEN_OBJECT_ID_TESTVAL.getBytes(
+        StandardCharsets.UTF_8);
     List<HandleAttribute> responseExpected = new ArrayList<>();
     responseExpected.add(new HandleAttribute(1, HANDLE.getBytes(StandardCharsets.UTF_8),
         NORMALISED_SPECIMEN_OBJECT_ID.get(), targetPhysicalIdentifier));
-    responseExpected.add(new HandleAttribute(2, HANDLE.getBytes(StandardCharsets.UTF_8), SPECIMEN_HOST.get(), SPECIMEN_HOST_TESTVAL.getBytes(
-        StandardCharsets.UTF_8)));
+    responseExpected.add(
+        new HandleAttribute(2, HANDLE.getBytes(StandardCharsets.UTF_8), SPECIMEN_HOST.get(),
+            SPECIMEN_HOST_TESTVAL.getBytes(
+                StandardCharsets.UTF_8)));
 
     List<HandleAttribute> nonTargetAttributes = new ArrayList<>();
     nonTargetAttributes.add(new HandleAttribute(1, HANDLE_ALT.getBytes(StandardCharsets.UTF_8),
@@ -264,7 +289,8 @@ class HandleRepositoryIT extends BaseRepositoryIT {
     postAttributes(nonTargetAttributes);
 
     // When
-    var responseReceived = handleRep.searchByNormalisedPhysicalIdentifierFullRecord(List.of(targetPhysicalIdentifier));
+    var responseReceived = handleRep.searchByNormalisedPhysicalIdentifierFullRecord(
+        List.of(targetPhysicalIdentifier));
 
     // Then
     assertThat(responseReceived).hasSameElementsAs(responseExpected);
@@ -429,11 +455,17 @@ class HandleRepositoryIT extends BaseRepositoryIT {
     var existingRecord = genHandleRecordAttributes(handle, ObjectType.HANDLE);
     postAttributes(existingRecord);
     var updatedRecord = new ArrayList<>(existingRecord);
-    updatedRecord.add(new HandleAttribute(MATERIAL_SAMPLE_TYPE.index(), handle, MATERIAL_SAMPLE_TYPE.get(), "digital".getBytes(StandardCharsets.UTF_8)));
-    updatedRecord.add(new HandleAttribute(PID_RECORD_ISSUE_NUMBER.index(), handle, PID_RECORD_ISSUE_NUMBER.get(), String.valueOf(2).getBytes(
-        StandardCharsets.UTF_8)));
-    updatedRecord.remove(new HandleAttribute(PID_RECORD_ISSUE_NUMBER.index(), handle, PID_RECORD_ISSUE_NUMBER.get(), String.valueOf(1).getBytes(
-        StandardCharsets.UTF_8)));
+    updatedRecord.add(
+        new HandleAttribute(MATERIAL_SAMPLE_TYPE.index(), handle, MATERIAL_SAMPLE_TYPE.get(),
+            "digital".getBytes(StandardCharsets.UTF_8)));
+    updatedRecord.add(
+        new HandleAttribute(PID_RECORD_ISSUE_NUMBER.index(), handle, PID_RECORD_ISSUE_NUMBER.get(),
+            String.valueOf(2).getBytes(
+                StandardCharsets.UTF_8)));
+    updatedRecord.remove(
+        new HandleAttribute(PID_RECORD_ISSUE_NUMBER.index(), handle, PID_RECORD_ISSUE_NUMBER.get(),
+            String.valueOf(1).getBytes(
+                StandardCharsets.UTF_8)));
 
     var newRecord = genHandleRecordAttributes(handleAlt, ObjectType.HANDLE);
     var expected = Stream.concat(updatedRecord.stream(), newRecord.stream()).toList();

--- a/src/test/java/eu/dissco/core/handlemanager/service/HandleServiceTest.java
+++ b/src/test/java/eu/dissco/core/handlemanager/service/HandleServiceTest.java
@@ -702,21 +702,19 @@ class HandleServiceTest {
         genCreateRecordRequest(newRecordRequest, RECORD_TYPE_DS),
         genCreateRecordRequest(existingRecordRequest, RECORD_TYPE_DS));
 
-    var existingRecordAttributes = genDigitalSpecimenAttributes(existingHandle);
-    var newRecordAttributes = genDigitalSpecimenAttributes(newHandle);
+    var existingRecordAttributes = genDigitalSpecimenAttributes(existingHandle, existingRecordRequest);
+    var newRecordAttributes = genDigitalSpecimenAttributes(newHandle, newRecordRequest);
     var primarySpecimenObjectIdAttributes = getPrimarySpecimenObjectIds(
         Stream.concat(existingRecordAttributes.stream(), newRecordAttributes.stream()).toList());
 
     var expected = new JsonApiWrapperWrite(
-        List.of(upsertedResponse(getPrimarySpecimenObjectIds(existingRecordAttributes),
-                new String(existingHandle, StandardCharsets.UTF_8)),
-            upsertedResponse(getPrimarySpecimenObjectIds(newRecordAttributes), new String(newHandle)))
-    );
+        List.of(upsertedResponse(getPrimarySpecimenObjectIds(newRecordAttributes), new String(newHandle)),
+            upsertedResponse(getPrimarySpecimenObjectIds(existingRecordAttributes),
+                new String(existingHandle, StandardCharsets.UTF_8))));
 
     given(handleRep.searchByNormalisedPhysicalIdentifier(anyList())).willReturn(
         List.of(new HandleAttribute(PRIMARY_SPECIMEN_OBJECT_ID.index(), existingHandle,
             PRIMARY_SPECIMEN_OBJECT_ID_TYPE.get(), (existingPhysId+":"+ROR_IDENTIFIER).getBytes(StandardCharsets.UTF_8))));
-    given(handleRep.getPrimarySpecimenObjectId(anyList())).willReturn(primarySpecimenObjectIdAttributes);
     given(fdoRecordService.prepareDigitalSpecimenRecordAttributes(eq(newRecordRequest), any(),
         any())).willReturn(newRecordAttributes);
     given(fdoRecordService.prepareUpdateAttributes(any(), eq(MAPPER.valueToTree(existingRecordRequest)), any())).willReturn(
@@ -766,7 +764,6 @@ class HandleServiceTest {
         List.of(new HandleAttribute(PRIMARY_SPECIMEN_OBJECT_ID.index(), handles.get(0),
             PRIMARY_SPECIMEN_OBJECT_ID.get(), (PRIMARY_SPECIMEN_OBJECT_ID_TESTVAL+":"+ROR_IDENTIFIER).getBytes(
             StandardCharsets.UTF_8))));
-    given(handleRep.getPrimarySpecimenObjectId(anyList())).willReturn(getPrimarySpecimenObjectIds(existingRecord));
     given(fdoRecordService.prepareUpdateAttributes(any(), any(), any())).willReturn(
         existingRecord);
     given(hgService.genHandleList(0)).willReturn(new ArrayList<>());
@@ -792,7 +789,6 @@ class HandleServiceTest {
     );
 
     given(handleRep.searchByNormalisedPhysicalIdentifier(anyList())).willReturn(new ArrayList<>());
-    given(handleRep.getPrimarySpecimenObjectId(anyList())).willReturn(getPrimarySpecimenObjectIds(newRecord));
     given(fdoRecordService.prepareDigitalSpecimenRecordAttributes(any(), any(), any())).willReturn(
         newRecord);
     given(hgService.genHandleList(anyInt())).willReturn(List.of(handles.get(0)));

--- a/src/test/java/eu/dissco/core/handlemanager/testUtils/TestUtils.java
+++ b/src/test/java/eu/dissco/core/handlemanager/testUtils/TestUtils.java
@@ -293,11 +293,8 @@ public class TestUtils {
     return fdoRecord;
   }
 
-  public static List<HandleAttribute> genDigitalSpecimenAttributes(byte[] handle)
-      throws Exception {
+  public static List<HandleAttribute> genDigitalSpecimenAttributes(byte[] handle, DigitalSpecimenRequest request) throws Exception{
     List<HandleAttribute> fdoRecord = genDoiRecordAttributes(handle, ObjectType.DIGITAL_SPECIMEN);
-    var request = givenDigitalSpecimenRequestObjectNullOptionals();
-
     // 200: Specimen Host
     fdoRecord.add(
         new HandleAttribute(SPECIMEN_HOST.index(), handle,
@@ -436,6 +433,13 @@ public class TestUtils {
     }
 
     return fdoRecord;
+
+  }
+
+  public static List<HandleAttribute> genDigitalSpecimenAttributes(byte[] handle)
+      throws Exception {
+    var request = givenDigitalSpecimenRequestObjectNullOptionals();
+    return genDigitalSpecimenAttributes(handle, request);
   }
 
   public static List<HandleAttribute> genMediaObjectAttributes(byte[] handle)


### PR DESCRIPTION
Upsert endpoint (used by specimen processor) returns very large objects. We only need to return the newly minted handle and the primaryPhysicalSpecimenObjectId. 

New Response looks like: 

`
{
    "data": [

        {

            "id": "20.5000.1025/FSL-ME2-9ZJ",

            "type": "digitalSpecimen",

            "attributes": {

                "primarySpecimenObjectId": "localId1"

            },

            "links": {

                "self": "https://hdl.handle.net/20.5000.1025/FSL-ME2-9ZJ"

            }

        },

        {

            "id": "20.5000.1025/0AL-NRE-7Y7",

            "type": "digitalSpecimen",

            "attributes": {

                "primarySpecimenObjectId": "localId2"

            },

            "links": {

                "self": "https://hdl.handle.net/20.5000.1025/0AL-NRE-7Y7"

            }

        }

    ]
}

`