### PR TITLE
add doi profile

### DIFF
--- a/src/main/java/eu/dissco/core/handlemanager/Profiles.java
+++ b/src/main/java/eu/dissco/core/handlemanager/Profiles.java
@@ -1,0 +1,9 @@
+package eu.dissco.core.handlemanager;
+
+public class Profiles {
+
+  public static final String DOI = "doi";
+
+  private Profiles() {
+  }
+}

--- a/src/main/java/eu/dissco/core/handlemanager/service/FdoRecordService.java
+++ b/src/main/java/eu/dissco/core/handlemanager/service/FdoRecordService.java
@@ -101,6 +101,7 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -116,6 +117,7 @@ import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Service;
 import org.w3c.dom.Document;
 
@@ -130,6 +132,7 @@ public class FdoRecordService {
   private final ObjectMapper mapper;
   private final HandleRepository handleRep;
   private final ApplicationProperties appProperties;
+  private final Environment env;
   private static final String HANDLE_DOMAIN = "https://hdl.handle.net/";
   private static final String ROR_API_DOMAIN = "https://api.ror.org/organizations/";
   private static final String ROR_DOMAIN = "https://ror.org/";
@@ -733,7 +736,11 @@ public class FdoRecordService {
   }
 
   private String[] concatLocations(String[] userLocations, String handle, ObjectType type) {
-    ArrayList<String> objectLocations = new ArrayList<>(List.of(defaultLocations(handle, type)));
+    ArrayList<String> objectLocations = new ArrayList<>();
+
+    if (!Arrays.asList(env.getActiveProfiles()).contains("doi")) {
+      objectLocations.addAll(List.of(defaultLocations(handle, type)));
+    }
     if (userLocations != null) {
       objectLocations.addAll(List.of(userLocations));
     }

--- a/src/main/java/eu/dissco/core/handlemanager/service/FdoRecordService.java
+++ b/src/main/java/eu/dissco/core/handlemanager/service/FdoRecordService.java
@@ -101,7 +101,6 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -738,7 +737,7 @@ public class FdoRecordService {
   private String[] concatLocations(String[] userLocations, String handle, ObjectType type) {
     ArrayList<String> objectLocations = new ArrayList<>();
 
-    if (!Arrays.asList(env.getActiveProfiles()).contains("doi")) {
+    if (!env.matchesProfiles("doi")) {
       objectLocations.addAll(List.of(defaultLocations(handle, type)));
     }
     if (userLocations != null) {

--- a/src/main/java/eu/dissco/core/handlemanager/service/FdoRecordService.java
+++ b/src/main/java/eu/dissco/core/handlemanager/service/FdoRecordService.java
@@ -75,6 +75,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import eu.dissco.core.handlemanager.Profiles;
 import eu.dissco.core.handlemanager.domain.FdoProfile;
 import eu.dissco.core.handlemanager.domain.repsitoryobjects.HandleAttribute;
 import eu.dissco.core.handlemanager.domain.requests.objects.AnnotationRequest;
@@ -737,7 +738,7 @@ public class FdoRecordService {
   private String[] concatLocations(String[] userLocations, String handle, ObjectType type) {
     ArrayList<String> objectLocations = new ArrayList<>();
 
-    if (!env.matchesProfiles("doi")) {
+    if (!env.matchesProfiles(Profiles.DOI)) {
       objectLocations.addAll(List.of(defaultLocations(handle, type)));
     }
     if (userLocations != null) {

--- a/src/test/java/eu/dissco/core/handlemanager/service/FdoRecordServiceTest.java
+++ b/src/test/java/eu/dissco/core/handlemanager/service/FdoRecordServiceTest.java
@@ -203,8 +203,7 @@ class FdoRecordServiceTest {
   private ApplicationProperties appProperties;
   @Mock
   Environment env;
-  private static final String[] defaultProfile = new String[]{"default"};
-  private static final String[] doiProfile = new String[]{"doi"};
+  private static final String DOI = "doi";
   private static final int HANDLE_QTY = 15;
   private static final int DOI_QTY = 19;
   private static final int MEDIA_QTY = DOI_QTY + 9;
@@ -221,7 +220,7 @@ class FdoRecordServiceTest {
     given(appProperties.getApiUrl()).willReturn(API_URL);
     given(appProperties.getOrchestrationUrl()).willReturn(ORCHESTRATION_URL);
     given(appProperties.getUiUrl()).willReturn(UI_URL);
-    given(env.getActiveProfiles()).willReturn(defaultProfile);
+    given(env.matchesProfiles(DOI)).willReturn(false);
   }
 
   @Test
@@ -262,7 +261,7 @@ class FdoRecordServiceTest {
     // Given
     given(pidResolver.getObjectName(any())).willReturn("placeholder");
     var request = givenDoiRecordRequestObject();
-    given(env.getActiveProfiles()).willReturn(doiProfile);
+    given(env.matchesProfiles(DOI)).willReturn(true);
 
     // When
     var result = fdoRecordService.prepareDoiRecordAttributes(request, handle, ObjectType.DOI);

--- a/src/test/java/eu/dissco/core/handlemanager/service/FdoRecordServiceTest.java
+++ b/src/test/java/eu/dissco/core/handlemanager/service/FdoRecordServiceTest.java
@@ -147,6 +147,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.springframework.core.env.Environment;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -200,6 +201,10 @@ class FdoRecordServiceTest {
   private HandleRepository handleRepository;
   @Mock
   private ApplicationProperties appProperties;
+  @Mock
+  Environment env;
+  private static final String[] defaultProfile = new String[]{"default"};
+  private static final String[] doiProfile = new String[]{"doi"};
   private static final int HANDLE_QTY = 15;
   private static final int DOI_QTY = 19;
   private static final int MEDIA_QTY = DOI_QTY + 9;
@@ -212,10 +217,11 @@ class FdoRecordServiceTest {
   @BeforeEach
   void init() {
     fdoRecordService = new FdoRecordService(TRANSFORMER_FACTORY, DOC_BUILDER_FACTORY, pidResolver,
-        MAPPER, handleRepository, appProperties);
+        MAPPER, handleRepository, appProperties, env);
     given(appProperties.getApiUrl()).willReturn(API_URL);
     given(appProperties.getOrchestrationUrl()).willReturn(ORCHESTRATION_URL);
     given(appProperties.getUiUrl()).willReturn(UI_URL);
+    given(env.getActiveProfiles()).willReturn(defaultProfile);
   }
 
   @Test
@@ -244,10 +250,29 @@ class FdoRecordServiceTest {
 
     // Then
     assertThat(result).hasSize(DOI_QTY);
-    assertThat(hasCorrectLocations(result, request.getLocations(), ObjectType.HANDLE)).isTrue();
+    assertThat(
+        hasCorrectLocations(result, request.getLocations(), ObjectType.HANDLE, false)).isTrue();
     assertThat(hasCorrectElements(result, HANDLE_FIELDS)).isTrue();
     assertThat(hasCorrectElements(result, DOI_FIELDS)).isTrue();
     assertThat(hasNoDuplicateElements(result)).isTrue();
+  }
+
+  @Test
+  void testPrepareDoiRecordAttributesDoiProfile() throws Exception {
+    // Given
+    given(pidResolver.getObjectName(any())).willReturn("placeholder");
+    var request = givenDoiRecordRequestObject();
+    given(env.getActiveProfiles()).willReturn(doiProfile);
+
+    // When
+    var result = fdoRecordService.prepareDoiRecordAttributes(request, handle, ObjectType.DOI);
+
+    // Then
+    assertThat(result).hasSize(DOI_QTY);
+    assertThat(hasCorrectElements(result, HANDLE_FIELDS)).isTrue();
+    assertThat(hasCorrectElements(result, DOI_FIELDS)).isTrue();
+    assertThat(hasNoDuplicateElements(result)).isTrue();
+    assertThat(hasCorrectLocations(result, request.getLocations(), ObjectType.DOI, true)).isTrue();
   }
 
   @Test
@@ -263,7 +288,8 @@ class FdoRecordServiceTest {
     // Then
     assertThat(result).hasSize(MEDIA_QTY);
     assertThat(
-        hasCorrectLocations(result, request.getLocations(), ObjectType.MEDIA_OBJECT)).isTrue();
+        hasCorrectLocations(result, request.getLocations(), ObjectType.MEDIA_OBJECT,
+            false)).isTrue();
     assertThat(hasNoDuplicateElements(result)).isTrue();
     assertThat(hasCorrectElements(result, MEDIA_FIELDS_MANDATORY)).isTrue();
     assertThat(result).contains(
@@ -297,7 +323,8 @@ class FdoRecordServiceTest {
     // Then
 
     assertThat(
-        hasCorrectLocations(result, request.getLocations(), ObjectType.MEDIA_OBJECT)).isTrue();
+        hasCorrectLocations(result, request.getLocations(), ObjectType.MEDIA_OBJECT,
+            false)).isTrue();
     assertThat(hasNoDuplicateElements(result)).isTrue();
     assertThat(hasCorrectElements(result, MEDIA_FIELDS_OPTIONAL)).isTrue();
     assertThat(result).hasSize(MEDIA_OPTIONAL_QTY);
@@ -319,7 +346,8 @@ class FdoRecordServiceTest {
     // Then
     assertThat(result).hasSize(MEDIA_QTY - 1);
     assertThat(
-        hasCorrectLocations(result, request.getLocations(), ObjectType.MEDIA_OBJECT)).isTrue();
+        hasCorrectLocations(result, request.getLocations(), ObjectType.MEDIA_OBJECT,
+            false)).isTrue();
     assertThat(hasNoDuplicateElements(result)).isTrue();
     assertThat(hasCorrectElements(result, MEDIA_FIELDS_MANDATORY)).isTrue();
   }
@@ -337,7 +365,8 @@ class FdoRecordServiceTest {
     // Then
     assertThat(result).hasSize(DS_MANDATORY_QTY);
     assertThat(
-        hasCorrectLocations(result, request.getLocations(), ObjectType.DIGITAL_SPECIMEN)).isTrue();
+        hasCorrectLocations(result, request.getLocations(), ObjectType.DIGITAL_SPECIMEN,
+            false)).isTrue();
     assertThat(hasCorrectElements(result, HANDLE_FIELDS)).isTrue();
     assertThat(hasCorrectElements(result, DOI_FIELDS)).isTrue();
     assertThat(hasCorrectElements(result, DS_FIELDS_MANDATORY)).isTrue();
@@ -415,7 +444,8 @@ class FdoRecordServiceTest {
     // Then
     assertThat(result).hasSize(DS_OPTIONAL_QTY);
     assertThat(
-        hasCorrectLocations(result, request.getLocations(), ObjectType.DIGITAL_SPECIMEN)).isTrue();
+        hasCorrectLocations(result, request.getLocations(), ObjectType.DIGITAL_SPECIMEN,
+            false)).isTrue();
     assertThat(hasCorrectElements(result, HANDLE_FIELDS)).isTrue();
     assertThat(hasCorrectElements(result, DOI_FIELDS)).isTrue();
     assertThat(hasCorrectElements(result, DS_FIELDS_MANDATORY)).isTrue();
@@ -437,7 +467,8 @@ class FdoRecordServiceTest {
 
     // Then
     assertThat(result).hasSize(ANNOTATION_QTY);
-    assertThat(hasCorrectLocations(result, request.getLocations(), ObjectType.ANNOTATION)).isTrue();
+    assertThat(
+        hasCorrectLocations(result, request.getLocations(), ObjectType.ANNOTATION, false)).isTrue();
     assertThat(hasCorrectElements(result, HANDLE_FIELDS)).isTrue();
     assertThat(hasCorrectElements(result, ANNOTATION_FIELDS)).isTrue();
     assertThat(hasNoDuplicateElements(result)).isTrue();
@@ -454,7 +485,7 @@ class FdoRecordServiceTest {
 
     // Then
     assertThat(result).hasSize(HANDLE_QTY + 1);
-    assertThat(hasCorrectLocations(result, request.getLocations(), ObjectType.MAS)).isTrue();
+    assertThat(hasCorrectLocations(result, request.getLocations(), ObjectType.MAS, false)).isTrue();
     assertThat(hasCorrectElements(result, HANDLE_FIELDS)).isTrue();
     assertThat(hasCorrectElements(result, Set.of(MAS_NAME.get()))).isTrue();
     assertThat(hasNoDuplicateElements(result)).isTrue();
@@ -503,7 +534,8 @@ class FdoRecordServiceTest {
     // Then
     assertThat(hasCorrectElements(result, HANDLE_FIELDS)).isTrue();
     assertThat(
-        hasCorrectLocations(result, request.getLocations(), ObjectType.SOURCE_SYSTEM)).isTrue();
+        hasCorrectLocations(result, request.getLocations(), ObjectType.SOURCE_SYSTEM,
+            false)).isTrue();
     assertThat(result).hasSize(HANDLE_QTY + 1);
     assertThat(hasNoDuplicateElements(result)).isTrue();
   }
@@ -803,8 +835,8 @@ class FdoRecordServiceTest {
   }
 
   private boolean hasCorrectLocations(List<HandleAttribute> fdoRecord, String[] userLocations,
-      ObjectType type) throws Exception {
-    var expectedLocations = new String(setLocations(userLocations, HANDLE, type));
+      ObjectType type, boolean isDoiProfileTest) throws Exception {
+    var expectedLocations = new String(setLocations(userLocations, HANDLE, type, isDoiProfileTest));
     for (var row : fdoRecord) {
       if (row.getType().equals(LOC.get())) {
         return (new String(row.getData(), StandardCharsets.UTF_8)).equals(expectedLocations);

--- a/src/test/java/eu/dissco/core/handlemanager/testUtils/TestUtils.java
+++ b/src/test/java/eu/dissco/core/handlemanager/testUtils/TestUtils.java
@@ -1081,7 +1081,7 @@ public class TestUtils {
   }
 
   public static byte[] setLocations(String[] userLocations, String handle, ObjectType type,
-      boolean isDoi)
+      boolean isDoiProfileTest)
       throws TransformerException, ParserConfigurationException {
     DOC_BUILDER_FACTORY.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
 
@@ -1090,7 +1090,8 @@ public class TestUtils {
     var doc = documentBuilder.newDocument();
     var locations = doc.createElement("locations");
     doc.appendChild(locations);
-    String[] objectLocations = isDoi ? userLocations : concatLocations(userLocations, handle, type);
+    String[] objectLocations = isDoiProfileTest
+        ? userLocations : concatLocations(userLocations, handle, type);
 
     for (int i = 0; i < objectLocations.length; i++) {
       var locs = doc.createElement("location");

--- a/src/test/java/eu/dissco/core/handlemanager/testUtils/TestUtils.java
+++ b/src/test/java/eu/dissco/core/handlemanager/testUtils/TestUtils.java
@@ -223,7 +223,7 @@ public class TestUtils {
     List<HandleAttribute> fdoRecord = new ArrayList<>();
     var request = givenHandleRecordRequestObject();
     byte[] loc = setLocations(request.getLocations(), new String(handle, StandardCharsets.UTF_8),
-        type);
+        type, false);
     var a = new String(loc, StandardCharsets.UTF_8);
     fdoRecord.add(new HandleAttribute(LOC.index(), handle, LOC.get(), loc));
 
@@ -294,11 +294,11 @@ public class TestUtils {
     List<HandleAttribute> attributes = genHandleRecordAttributes(handle, ObjectType.HANDLE);
 
     byte[] locOriginal = setLocations(LOC_TESTVAL, new String(handle, StandardCharsets.UTF_8),
-        ObjectType.HANDLE);
+        ObjectType.HANDLE, false);
     var locOriginalAttr = new HandleAttribute(LOC.index(), handle, LOC.get(), locOriginal);
 
     byte[] locAlt = setLocations(LOC_ALT_TESTVAL, new String(handle, StandardCharsets.UTF_8),
-        ObjectType.HANDLE);
+        ObjectType.HANDLE, false);
     var locAltAttr = new HandleAttribute(LOC.index(), handle, LOC.get(), locAlt);
 
     attributes.set(attributes.indexOf(locOriginalAttr), locAltAttr);
@@ -322,7 +322,7 @@ public class TestUtils {
   public static List<HandleAttribute> genUpdateRecordAttributesAltLoc(byte[] handle)
       throws ParserConfigurationException, TransformerException {
     byte[] locAlt = setLocations(LOC_ALT_TESTVAL, new String(handle, StandardCharsets.UTF_8),
-        ObjectType.HANDLE);
+        ObjectType.HANDLE, false);
     return List.of(new HandleAttribute(LOC.index(), handle, LOC.get(), locAlt));
   }
 
@@ -1072,7 +1072,7 @@ public class TestUtils {
 
   public static byte[] givenLandingPage(String handle) throws Exception {
     var landingPage = new String[]{"Placeholder landing page"};
-    return setLocations(landingPage, handle, ObjectType.TOMBSTONE);
+    return setLocations(landingPage, handle, ObjectType.TOMBSTONE, false);
   }
 
   public static HandleAttribute givenLandingPageAttribute(byte[] handle) throws Exception {
@@ -1080,7 +1080,8 @@ public class TestUtils {
     return new HandleAttribute(LOC.index(), handle, LOC.get(), data);
   }
 
-  public static byte[] setLocations(String[] userLocations, String handle, ObjectType type)
+  public static byte[] setLocations(String[] userLocations, String handle, ObjectType type,
+      boolean isDoi)
       throws TransformerException, ParserConfigurationException {
     DOC_BUILDER_FACTORY.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
 
@@ -1089,7 +1090,7 @@ public class TestUtils {
     var doc = documentBuilder.newDocument();
     var locations = doc.createElement("locations");
     doc.appendChild(locations);
-    String[] objectLocations = concatLocations(userLocations, handle, type);
+    String[] objectLocations = isDoi ? userLocations : concatLocations(userLocations, handle, type);
 
     for (int i = 0; i < objectLocations.length; i++) {
       var locs = doc.createElement("location");


### PR DESCRIPTION
Added doi profile specifically to set locations for DOIs.

Default Profile behaviour: build 10320/loc attribute urls based on minted handle, and potentially user-inputted locations
DOI Profile behaviour: only use user inputted locations. otherwise it would point to something like https://sandbox.dissco.tech/ds.10.555/qwe-8sq-2, which doesn't exist. 

More features should be added to DOI profile, that's a next week thing