### PR TITLE
Upsert specimens

### DIFF
--- a/src/main/java/eu/dissco/core/handlemanager/domain/FdoProfile.java
+++ b/src/main/java/eu/dissco/core/handlemanager/domain/FdoProfile.java
@@ -97,7 +97,7 @@ public enum FdoProfile {
   private final int index;
 
 
-  private FdoProfile(String attribute, int index) {
+  FdoProfile(String attribute, int index) {
     this.attribute = attribute;
     this.index = index;
   }

--- a/src/main/java/eu/dissco/core/handlemanager/domain/requests/objects/DigitalSpecimenUpdateWrapper.java
+++ b/src/main/java/eu/dissco/core/handlemanager/domain/requests/objects/DigitalSpecimenUpdateWrapper.java
@@ -1,0 +1,8 @@
+package eu.dissco.core.handlemanager.domain.requests.objects;
+
+public record DigitalSpecimenUpdateWrapper(
+    String handle,
+    DigitalSpecimenRequest digitalSpecimenRequest
+) {
+
+}

--- a/src/main/java/eu/dissco/core/handlemanager/domain/requests/objects/ProcessedDigitalSpecimenRequest.java
+++ b/src/main/java/eu/dissco/core/handlemanager/domain/requests/objects/ProcessedDigitalSpecimenRequest.java
@@ -1,0 +1,10 @@
+package eu.dissco.core.handlemanager.domain.requests.objects;
+
+import java.util.List;
+
+public record ProcessedDigitalSpecimenRequest(
+    List<DigitalSpecimenRequest> newRequests,
+    List<DigitalSpecimenUpdateWrapper> updateRequests
+) {
+
+}

--- a/src/main/java/eu/dissco/core/handlemanager/domain/requests/vocabulary/specimen/BaseTypeOfSpecimen.java
+++ b/src/main/java/eu/dissco/core/handlemanager/domain/requests/vocabulary/specimen/BaseTypeOfSpecimen.java
@@ -4,12 +4,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public enum BaseTypeOfSpecimen {
   @JsonProperty("Material entity") MATERIAL("Material entity"),
-  @JsonProperty("Information artefact") INFO("informationArtefact");
+  @JsonProperty("Information artefact") INFO("Information Artefact");
 
   private final String state;
 
 
-  private BaseTypeOfSpecimen(String state) {
+  BaseTypeOfSpecimen(String state) {
     this.state = state;
   }
 

--- a/src/main/java/eu/dissco/core/handlemanager/domain/requests/vocabulary/specimen/MaterialSampleType.java
+++ b/src/main/java/eu/dissco/core/handlemanager/domain/requests/vocabulary/specimen/MaterialSampleType.java
@@ -7,12 +7,12 @@ public enum MaterialSampleType {
   @JsonProperty("Whole organism specimen") WHOLE_ORG("Whole organism specimen"),
   @JsonProperty("Organism part") ORG_PART("Organism part"),
   @JsonProperty("Organism product") ORG_PRODUCT("Organism product"),
-  @JsonProperty("Biome aggegation") AGGR_BIOME("Biome aggegation"),
+  @JsonProperty("Biome aggregation") AGGR_BIOME("Biome aggregation"),
   @JsonProperty("Bundle biome aggregation") BUNDLE_BIOME("Bundle biome aggregation"),
   @JsonProperty("Fossil") FOSSIL("Fossil"),
   @JsonProperty("Any biological specimen") ANY_BIO("Any biological specimen"),
   @JsonProperty("Aggregation") AGGR("Aggregation"),
-  @JsonProperty("Slurry biome aggegation") SLURRY_BIOME("Slurry biome aggegation"),
+  @JsonProperty("Slurry biome aggregation") SLURRY_BIOME("Slurry biome aggregation"),
   @JsonProperty("Other solid object") OTHER_SOLID("Other solid object"),
   @JsonProperty("Fluid in container") FLUID("Fluid in container"),
   @JsonProperty("Anthropogenic aggregation") ANTHRO_AGGR("Anthropogenic aggregation"),
@@ -22,7 +22,7 @@ public enum MaterialSampleType {
 
   private final String state;
 
-  private MaterialSampleType(String state) {
+  MaterialSampleType(String state) {
     this.state = state;
   }
 

--- a/src/main/java/eu/dissco/core/handlemanager/service/DoiService.java
+++ b/src/main/java/eu/dissco/core/handlemanager/service/DoiService.java
@@ -50,8 +50,9 @@ public class DoiService extends PidService {
     List<HandleAttribute> handleAttributes;
     try {
       switch (type) {
-        case DIGITAL_SPECIMEN ->
-            handleAttributes = createDigitalSpecimen(requestAttributes, handles);
+        case DIGITAL_SPECIMEN -> {
+          return upsertDigitalSpecimen(requestAttributes, handles);
+        }
         case MEDIA_OBJECT -> handleAttributes = createMediaObject(requestAttributes, handles);
         default -> throw new UnsupportedOperationException(
             type + " is not an appropriate Type for DOI endpoint.");

--- a/src/main/java/eu/dissco/core/handlemanager/service/HandleService.java
+++ b/src/main/java/eu/dissco/core/handlemanager/service/HandleService.java
@@ -53,8 +53,9 @@ public class HandleService extends PidService {
     try {
       switch (type) {
         case ANNOTATION -> handleAttributes = createAnnotation(requestAttributes, handles);
-        case DIGITAL_SPECIMEN ->
-            handleAttributes = createDigitalSpecimen(requestAttributes, handles);
+        case DIGITAL_SPECIMEN -> {
+          return upsertDigitalSpecimen(requestAttributes, handles);
+        }
         case DOI -> handleAttributes = createDoi(requestAttributes, handles);
         case HANDLE -> handleAttributes = createHandle(requestAttributes, handles);
         case MAPPING -> handleAttributes = createMapping(requestAttributes, handles);

--- a/src/main/java/eu/dissco/core/handlemanager/service/PidService.java
+++ b/src/main/java/eu/dissco/core/handlemanager/service/PidService.java
@@ -27,7 +27,9 @@ import eu.dissco.core.handlemanager.domain.jsonapi.JsonApiWrapperReadSingle;
 import eu.dissco.core.handlemanager.domain.jsonapi.JsonApiWrapperWrite;
 import eu.dissco.core.handlemanager.domain.repsitoryobjects.HandleAttribute;
 import eu.dissco.core.handlemanager.domain.requests.objects.DigitalSpecimenRequest;
+import eu.dissco.core.handlemanager.domain.requests.objects.DigitalSpecimenUpdateWrapper;
 import eu.dissco.core.handlemanager.domain.requests.objects.MediaObjectRequest;
+import eu.dissco.core.handlemanager.domain.requests.objects.ProcessedDigitalSpecimenRequest;
 import eu.dissco.core.handlemanager.domain.requests.vocabulary.specimen.ObjectType;
 import eu.dissco.core.handlemanager.exceptions.InvalidRequestException;
 import eu.dissco.core.handlemanager.exceptions.PidCreationException;
@@ -38,7 +40,7 @@ import eu.dissco.core.handlemanager.repository.PidRepository;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -280,36 +282,96 @@ public abstract class PidService {
     return ObjectType.fromString(type.get());
   }
 
-  protected ArrayList<HandleAttribute> createDigitalSpecimen(List<JsonNode> requestAttributes,
+  protected JsonApiWrapperWrite upsertDigitalSpecimen(List<JsonNode> requestAttributes,
       Iterator<byte[]> handleIterator)
-      throws InvalidRequestException, JsonProcessingException, PidResolutionException {
-    var handleAttributes = new ArrayList<HandleAttribute>();
-    var physicalIds = new ArrayList<byte[]>();
+      throws InvalidRequestException, JsonProcessingException, PidResolutionException, PidCreationException {
+    var specimenRequests = new ArrayList<DigitalSpecimenRequest>();
     for (var request : requestAttributes) {
-      var thisHandle = handleIterator.next();
-      var requestObject = mapper.treeToValue(request, DigitalSpecimenRequest.class);
-      physicalIds.add(
-          requestObject.getNormalisedPrimarySpecimenObjectId().getBytes(StandardCharsets.UTF_8));
-      handleAttributes.addAll(
-          fdoRecordService.prepareDigitalSpecimenRecordAttributes(requestObject, thisHandle));
+      specimenRequests.add(mapper.treeToValue(request, DigitalSpecimenRequest.class));
     }
-    verifyNoRegisteredSpecimens(physicalIds);
+    var processResult = processSpecimenRequests(specimenRequests);
+    var recordTimeStamp = Instant.now().getEpochSecond();
+    var pidAttributes = createNewDigitalSpecimenRecords(processResult.newRequests(), handleIterator,
+        recordTimeStamp);
+    pidAttributes.addAll(updateDigitalSpecimen(processResult.updateRequests(), recordTimeStamp));
+    return new JsonApiWrapperWrite(formatCreateRecordsSpecimen(mapRecords(pidAttributes)));
+  }
+
+  private ArrayList<HandleAttribute> createNewDigitalSpecimenRecords(
+      List<DigitalSpecimenRequest> specimenRequests, Iterator<byte[]> handleIterator,
+      long recordTimestamp)
+      throws PidResolutionException, InvalidRequestException, PidCreationException {
+    if (specimenRequests.isEmpty()) {
+      return new ArrayList<>();
+    }
+    var handleAttributes = new ArrayList<HandleAttribute>();
+    for (var request : specimenRequests) {
+      var thisHandle = handleIterator.next();
+      handleAttributes.addAll(
+          fdoRecordService.prepareDigitalSpecimenRecordAttributes(request, thisHandle));
+    }
+    log.info("Posting {} new digital specimen fdo records to db", specimenRequests.size());
+    pidRepository.postAttributesToDb(recordTimestamp, handleAttributes);
     return handleAttributes;
   }
 
-  protected void verifyNoRegisteredSpecimens(List<byte[]> physicalIds)
-      throws PidResolutionException {
-    var registeredRows = pidRepository.searchByNormalisedPhysicalIdentifier(
-        physicalIds);
-    if (!registeredRows.isEmpty()) {
-      var registeredHandles = registeredRows.stream()
-          .map(row -> new String(row.getHandle(), StandardCharsets.UTF_8)).toList();
-      log.error("Attempting to register identifiers for existing records");
-      log.debug("Handles already registered: {}", registeredHandles);
-      throw new PidResolutionException(
-          "Unable to create PID records. Some requested records are already registered. Verify the following digital specimens:"
-              + registeredHandles);
+  protected List<HandleAttribute> updateDigitalSpecimen(
+      List<DigitalSpecimenUpdateWrapper> updateRequests, long recordTimestamp)
+      throws InvalidRequestException, PidResolutionException {
+    if (updateRequests.isEmpty()) {
+      return Collections.emptyList();
     }
+    List<List<HandleAttribute>> attributesToUpdate = new ArrayList<>();
+    List<HandleAttribute> flatList = new ArrayList<>();
+    for (var request : updateRequests) {
+      var requestAttributes = mapper.valueToTree(request.digitalSpecimenRequest());
+      flatList.addAll(fdoRecordService.prepareUpdateAttributes(
+          request.handle().getBytes(StandardCharsets.UTF_8), requestAttributes, DIGITAL_SPECIMEN));
+      attributesToUpdate.add(flatList);
+    }
+    log.info("Updating {} digital specimen fdo records to db", updateRequests.size());
+    pidRepository.updateRecordBatch(recordTimestamp, attributesToUpdate, true);
+    return flatList;
+  }
+
+  private ProcessedDigitalSpecimenRequest processSpecimenRequests(
+      ArrayList<DigitalSpecimenRequest> specimenRequests) {
+    var physicalIds = specimenRequests.stream()
+        .map(request -> request.getNormalisedPrimarySpecimenObjectId().getBytes(
+            StandardCharsets.UTF_8)).toList();
+    var registeredPhysicalIdentifiers = pidRepository.searchByNormalisedPhysicalIdentifier(
+        physicalIds);
+    var registeredPhysicalIdentiferMap = registeredPhysicalIdentifiers.stream()
+        .collect(Collectors.toMap(row -> new String(row.getData(), StandardCharsets.UTF_8),
+            row -> new String(row.getHandle(), StandardCharsets.UTF_8)));
+    var writableHandles = pidRepository.checkHandlesWritable(
+            registeredPhysicalIdentiferMap.values().stream().map(s -> s.getBytes(
+                StandardCharsets.UTF_8)).toList()).stream()
+        .map(h -> new String(h, StandardCharsets.UTF_8)).collect(Collectors.toSet());
+    var updates = specimenRequests.stream()
+        .filter(request -> requestExistsAndIsWriteable(request, registeredPhysicalIdentiferMap,
+            writableHandles))
+        .map(request -> new DigitalSpecimenUpdateWrapper(
+            registeredPhysicalIdentiferMap.get(request.getNormalisedPrimarySpecimenObjectId()),
+            request
+        ))
+        .toList();
+    if (!updates.isEmpty()) {
+      log.debug("Existing records: {}",
+          updates.stream().map(DigitalSpecimenUpdateWrapper::handle).toList());
+    }
+    specimenRequests.removeAll(
+        updates.stream().map(DigitalSpecimenUpdateWrapper::digitalSpecimenRequest).toList());
+
+    return new ProcessedDigitalSpecimenRequest(specimenRequests, updates);
+  }
+
+  private boolean requestExistsAndIsWriteable(DigitalSpecimenRequest request,
+      Map<String, String> registeredPhysicalIdentifiers, Set<String> writableHandles) {
+    return registeredPhysicalIdentifiers.containsKey(request.getNormalisedPrimarySpecimenObjectId())
+        &&
+        writableHandles.contains(
+            registeredPhysicalIdentifiers.get(request.getNormalisedPrimarySpecimenObjectId()));
   }
 
   protected List<HandleAttribute> createMediaObject(List<JsonNode> requestAttributes,
@@ -332,14 +394,13 @@ public abstract class PidService {
     var recordTimestamp = Instant.now().getEpochSecond();
     List<byte[]> handles = new ArrayList<>();
     List<List<HandleAttribute>> attributesToUpdate = new ArrayList<>();
-    Map<String, ObjectType> recordTypes = new HashMap<>();
+    var recordType = getObjectType(requests);
     for (JsonNode root : requests) {
       JsonNode data = root.get(NODE_DATA);
       byte[] handle = data.get(NODE_ID).asText().getBytes(StandardCharsets.UTF_8);
       handles.add(handle);
       JsonNode requestAttributes = data.get(NODE_ATTRIBUTES);
       ObjectType type = ObjectType.fromString(data.get(NODE_TYPE).asText());
-      recordTypes.put(new String(handle, StandardCharsets.UTF_8), type);
       var attributes = fdoRecordService.prepareUpdateAttributes(handle, requestAttributes, type);
       attributesToUpdate.add(attributes);
     }
@@ -347,7 +408,7 @@ public abstract class PidService {
     checkHandlesWritable(handles);
 
     pidRepository.updateRecordBatch(recordTimestamp, attributesToUpdate, incrementVersion);
-    return formatUpdates(attributesToUpdate, recordTypes);
+    return formatUpdates(attributesToUpdate, recordType);
   }
 
   protected void checkInternalDuplicates(List<byte[]> handles) throws InvalidRequestException {
@@ -375,13 +436,12 @@ public abstract class PidService {
   }
 
   protected JsonApiWrapperWrite formatUpdates(List<List<HandleAttribute>> updatedRecords,
-      Map<String, ObjectType> recordTypes) {
+      ObjectType type) {
     List<JsonApiDataLinks> dataList = new ArrayList<>();
     for (var updatedRecord : updatedRecords) {
       String handle = new String(updatedRecord.get(0).getHandle(), StandardCharsets.UTF_8);
       var attributeNode = jsonFormatSingleRecord(updatedRecord);
-      var type = recordTypes.get(handle).toString();
-      dataList.add(new JsonApiDataLinks(handle, type, attributeNode,
+      dataList.add(new JsonApiDataLinks(handle, type.toString(), attributeNode,
           new JsonApiLinks(profileProperties.getDomain() + handle)));
     }
     return new JsonApiWrapperWrite(dataList);

--- a/src/main/java/eu/dissco/core/handlemanager/service/PidService.java
+++ b/src/main/java/eu/dissco/core/handlemanager/service/PidService.java
@@ -344,13 +344,9 @@ public abstract class PidService {
     var registeredPhysicalIdentiferMap = registeredPhysicalIdentifiers.stream()
         .collect(Collectors.toMap(row -> new String(row.getData(), StandardCharsets.UTF_8),
             row -> new String(row.getHandle(), StandardCharsets.UTF_8)));
-    var writableHandles = pidRepository.checkHandlesWritable(
-            registeredPhysicalIdentiferMap.values().stream().map(s -> s.getBytes(
-                StandardCharsets.UTF_8)).toList()).stream()
-        .map(h -> new String(h, StandardCharsets.UTF_8)).collect(Collectors.toSet());
     var updates = specimenRequests.stream()
-        .filter(request -> requestExistsAndIsWriteable(request, registeredPhysicalIdentiferMap,
-            writableHandles))
+        .filter(request -> registeredPhysicalIdentiferMap.containsKey(
+            request.getNormalisedPrimarySpecimenObjectId()))
         .map(request -> new DigitalSpecimenUpdateWrapper(
             registeredPhysicalIdentiferMap.get(request.getNormalisedPrimarySpecimenObjectId()),
             request
@@ -364,14 +360,6 @@ public abstract class PidService {
         updates.stream().map(DigitalSpecimenUpdateWrapper::digitalSpecimenRequest).toList());
 
     return new ProcessedDigitalSpecimenRequest(specimenRequests, updates);
-  }
-
-  private boolean requestExistsAndIsWriteable(DigitalSpecimenRequest request,
-      Map<String, String> registeredPhysicalIdentifiers, Set<String> writableHandles) {
-    return registeredPhysicalIdentifiers.containsKey(request.getNormalisedPrimarySpecimenObjectId())
-        &&
-        writableHandles.contains(
-            registeredPhysicalIdentifiers.get(request.getNormalisedPrimarySpecimenObjectId()));
   }
 
   protected List<HandleAttribute> createMediaObject(List<JsonNode> requestAttributes,

--- a/src/test/java/eu/dissco/core/handlemanager/repository/PidRepositoryIT.java
+++ b/src/test/java/eu/dissco/core/handlemanager/repository/PidRepositoryIT.java
@@ -323,6 +323,24 @@ class PidRepositoryIT extends BaseRepositoryIT {
   }
 
   @Test
+  void testSearchByPhysicalSpecimenIdIsArchived() {
+    //Given
+    var handle = HANDLE.getBytes(StandardCharsets.UTF_8);
+    var record = List.of(new HandleAttribute(NORMALISED_SPECIMEN_OBJECT_ID, handle,
+            NORMALISED_PRIMARY_SPECIMEN_OBJECT_ID_TESTVAL),
+        new HandleAttribute(PID_STATUS, handle, "ARCHIVED"));
+
+    postAttributes(record);
+
+    // When
+    var response = pidRepository.searchByNormalisedPhysicalIdentifier(
+        List.of(NORMALISED_PRIMARY_SPECIMEN_OBJECT_ID_TESTVAL.getBytes(StandardCharsets.UTF_8)));
+
+    // Then
+    assertThat(response).isEmpty();
+  }
+
+  @Test
   void testUpdateRecord() throws Exception {
     // Given
     byte[] handle = HANDLE.getBytes(StandardCharsets.UTF_8);

--- a/src/test/java/eu/dissco/core/handlemanager/service/HandleServiceTest.java
+++ b/src/test/java/eu/dissco/core/handlemanager/service/HandleServiceTest.java
@@ -378,7 +378,6 @@ class HandleServiceTest {
         ObjectType.DIGITAL_SPECIMEN);
 
     given(pidNameGeneratorService.genHandleList(1)).willReturn(new ArrayList<>(List.of(handle)));
-    given(pidRepository.checkHandlesWritable(anyList())).willReturn(List.of(handle));
     given(profileProperties.getDomain()).willReturn(HANDLE_DOMAIN);
     given(pidRepository.searchByNormalisedPhysicalIdentifier(anyList())).willReturn(List.of(
         new HandleAttribute(FdoProfile.NORMALISED_SPECIMEN_OBJECT_ID, handle,
@@ -392,37 +391,6 @@ class HandleServiceTest {
     // Then
     then(pidRepository).should()
         .updateRecordBatch(CREATED.getEpochSecond(), List.of(digitalSpecimenAttributes), true);
-    assertThat(result).isEqualTo(responseExpected);
-  }
-
-  @Test
-  void testCreateDigitalSpecimenSpecimenExistsNotWritable() throws Exception {
-    // Given
-    byte[] handle = handles.get(0);
-    var digitalSpecimen = givenDigitalSpecimenRequestObjectNullOptionals();
-    var request = genCreateRecordRequest(digitalSpecimen,
-        RECORD_TYPE_DS);
-    List<HandleAttribute> digitalSpecimenAttributes = genDigitalSpecimenAttributes(handle);
-    var digitalSpecimenSublist = digitalSpecimenAttributes.stream()
-        .filter(row -> row.getType().equals(PRIMARY_SPECIMEN_OBJECT_ID.get())).toList();
-    var responseExpected = givenRecordResponseWriteSmallResponse(digitalSpecimenSublist,
-        List.of(handle),
-        ObjectType.DIGITAL_SPECIMEN);
-
-    given(pidNameGeneratorService.genHandleList(1)).willReturn(new ArrayList<>(List.of(handle)));
-    given(profileProperties.getDomain()).willReturn(HANDLE_DOMAIN);
-    given(pidRepository.searchByNormalisedPhysicalIdentifier(anyList())).willReturn(List.of(
-        new HandleAttribute(FdoProfile.NORMALISED_SPECIMEN_OBJECT_ID, handle,
-            digitalSpecimen.getNormalisedPrimarySpecimenObjectId())));
-    given(fdoRecordService.prepareDigitalSpecimenRecordAttributes(digitalSpecimen,
-        handle)).willReturn(digitalSpecimenAttributes);
-
-    // When
-    var result = service.createRecords(List.of(request));
-
-    // Then
-    then(pidRepository).should()
-        .postAttributesToDb(CREATED.getEpochSecond(), digitalSpecimenAttributes);
     assertThat(result).isEqualTo(responseExpected);
   }
 


### PR DESCRIPTION
Re-adds upsert endpoint. New specimens are Postgres-Copied. Updated specimens are inserted with Jooq. 

We don't verify media objects/annotations haven't been ingested the way we verify specimens. For media/annotation objects, we rely on the respective processing services to verify they haven't been ingested. It might make sense with media objects (since they'll eventually get DOIs), but for annotations, it probably isn't necessary. 

