### PR TITLE
other specimen ids in fdo profile

### DIFF
--- a/.github/workflows/.trivyignore
+++ b/.github/workflows/.trivyignore
@@ -2,3 +2,8 @@
 # Issue: Libexpat, parsing large tokens can trigger a denial of service
 # Solution: Update docker image
 CVE-2023-52425
+
+# Date: March 21, 2024
+# Issue: Vulnerability in spring-web
+# Solution: Spring boot needs to update its version of spring
+CVE-2024-22259

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>spring-boot-starter-parent</artifactId>
     <groupId>org.springframework.boot</groupId>
     <relativePath/>
-    <version>3.2.2</version> <!-- lookup parent from repository -->
+    <version>3.2.3</version> <!-- lookup parent from repository -->
   </parent>
   <artifactId>handle-manager</artifactId>
   <version>0.0.1-SNAPSHOT</version>

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
     </sonar.coverage.jacoco.xmlReportPaths>
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     <sonar.organization>dissco</sonar.organization>
+    <spring-security.version>6.2.3</spring-security.version> <!-- 21/03/24: CVE-2024-22257-->
     <version.victools>4.28.0</version.victools>
   </properties>
 

--- a/src/main/java/eu/dissco/core/handlemanager/domain/requests/objects/OtherSpecimenId.java
+++ b/src/main/java/eu/dissco/core/handlemanager/domain/requests/objects/OtherSpecimenId.java
@@ -1,5 +1,5 @@
 package eu.dissco.core.handlemanager.domain.requests.objects;
 
-public record OtherSpecimenId(String id, String idType, String idName) {
+public record OtherSpecimenId(String identifierValue, String identifierType) {
 
 }

--- a/src/test/java/eu/dissco/core/handlemanager/service/FdoRecordServiceTest.java
+++ b/src/test/java/eu/dissco/core/handlemanager/service/FdoRecordServiceTest.java
@@ -750,7 +750,7 @@ class FdoRecordServiceTest {
         PRIMARY_REFERENT_TYPE_TESTVAL, SPECIMEN_HOST_TESTVAL, SPECIMEN_HOST_NAME_TESTVAL,
         PRIMARY_SPECIMEN_OBJECT_ID_TESTVAL, PrimarySpecimenObjectIdType.LOCAL, "b",
         NORMALISED_PRIMARY_SPECIMEN_OBJECT_ID_TESTVAL, null,
-        List.of(new OtherSpecimenId("Id", "local identifier", "id for institute")),
+        List.of(new OtherSpecimenId("Id", "local identifier")),
         TopicOrigin.NATURAL, TopicDomain.LIFE, TopicDiscipline.ZOO, TopicCategory.AMPHIBIANS,
         LivingOrPreserved.LIVING, BaseTypeOfSpecimen.INFO, InformationArtefactType.MOVING_IMG,
         MaterialSampleType.ORG_PART, MaterialOrDigitalEntity.DIGITAL, false, HANDLE_ALT,


### PR DESCRIPTION
the fdo profile field "otherSpecimenIds" needs to align with the digital specimen field "Identifiers"

[Jira](https://naturalis.atlassian.net/browse/DD-972?atlOrigin=eyJpIjoiNDRkZjgyNGUzZmI2NDAyYTkyZDhmMDdlOGFkMjdhZDkiLCJwIjoiaiJ9)

Related PRs
- [OpenDS](https://github.com/DiSSCo/openDS/compare/feature/align-other-specimen-ids?expand=1)
- [Processor](https://github.com/DiSSCo/dissco-core-digital-specimen-processor/pull/45)
