### PR TITLE
Clean up exceptions

### DIFF
--- a/src/main/java/eu/dissco/core/handlemanager/controller/PidController.java
+++ b/src/main/java/eu/dissco/core/handlemanager/controller/PidController.java
@@ -10,11 +10,8 @@ import eu.dissco.core.handlemanager.domain.jsonapi.JsonApiWrapperReadSingle;
 import eu.dissco.core.handlemanager.domain.jsonapi.JsonApiWrapperWrite;
 import eu.dissco.core.handlemanager.domain.requests.RollbackRequest;
 import eu.dissco.core.handlemanager.domain.validation.JsonSchemaValidator;
-import eu.dissco.core.handlemanager.exceptions.DatabaseCopyException;
 import eu.dissco.core.handlemanager.exceptions.InvalidRequestException;
-import eu.dissco.core.handlemanager.exceptions.PidCreationException;
 import eu.dissco.core.handlemanager.exceptions.PidResolutionException;
-import eu.dissco.core.handlemanager.exceptions.UnprocessableEntityException;
 import eu.dissco.core.handlemanager.properties.ApplicationProperties;
 import eu.dissco.core.handlemanager.service.PidService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -52,13 +49,11 @@ public class PidController {
   private final ApplicationProperties applicationProperties;
   private static final int LOG_LIMIT = 4;
 
-
   // Getters
   @Operation(summary = "Resolve single PID record")
   @GetMapping("/{prefix}/{suffix}")
   public ResponseEntity<JsonApiWrapperReadSingle> resolvePid(@PathVariable("prefix") String prefix,
-      @PathVariable("suffix") String suffix, HttpServletRequest r)
-      throws PidResolutionException {
+      @PathVariable("suffix") String suffix, HttpServletRequest r) {
     String path = applicationProperties.getUiUrl() + r.getRequestURI();
     String handle = prefix + "/" + suffix;
 
@@ -75,7 +70,7 @@ public class PidController {
   @GetMapping("/records")
   public ResponseEntity<JsonApiWrapperRead> resolvePids(
       @RequestParam List<String> handles,
-      HttpServletRequest r) throws PidResolutionException, InvalidRequestException {
+      HttpServletRequest r) {
     String path = applicationProperties.getUiUrl() + r.getRequestURI();
 
     if (handles.size() > applicationProperties.getMaxHandles()) {
@@ -92,8 +87,7 @@ public class PidController {
   @Operation(summary = "Given a physical identifier (i.e. local identifier), resolve PID record")
   @GetMapping("/records/primarySpecimenObjectId")
   public ResponseEntity<JsonApiWrapperWrite> searchByPrimarySpecimenObjectId(
-      @RequestParam String normalisedPrimarySpecimenObjectId)
-      throws PidResolutionException {
+      @RequestParam String normalisedPrimarySpecimenObjectId) {
     return ResponseEntity.status(HttpStatus.OK).body(
         service.searchByPhysicalSpecimenId(normalisedPrimarySpecimenObjectId));
   }
@@ -101,8 +95,7 @@ public class PidController {
   @Operation(summary = "Create single PID Record")
   @PostMapping(value = "/")
   public ResponseEntity<JsonApiWrapperWrite> createRecord(@RequestBody JsonNode request,
-      Authentication authentication)
-      throws PidResolutionException, InvalidRequestException, PidCreationException, DatabaseCopyException {
+      Authentication authentication) {
     log.info("Received single POST request from user {}", authentication.getName());
     schemaValidator.validatePostRequest(request);
     return ResponseEntity.status(HttpStatus.CREATED).body(service.createRecords(List.of(request)
@@ -112,8 +105,7 @@ public class PidController {
   @Operation(summary = "Create multiple PID Records at a time.")
   @PostMapping(value = "/batch")
   public ResponseEntity<JsonApiWrapperWrite> createRecords(@RequestBody List<JsonNode> requests,
-      Authentication authentication)
-      throws PidResolutionException, InvalidRequestException, PidCreationException, DatabaseCopyException {
+      Authentication authentication) {
     log.info("Validating batch POST request from user {}", authentication.getName());
     for (JsonNode request : requests) {
       schemaValidator.validatePostRequest(request);
@@ -126,8 +118,7 @@ public class PidController {
   @PatchMapping(value = "/{prefix}/{suffix}")
   public ResponseEntity<JsonApiWrapperWrite> updateRecord(@PathVariable("prefix") String prefix,
       @PathVariable("suffix") String suffix, @RequestBody JsonNode request,
-      Authentication authentication)
-      throws InvalidRequestException, PidResolutionException, UnprocessableEntityException {
+      Authentication authentication) {
     log.info("Received single update request for PID {}/{} from user {}", prefix, suffix,
         authentication.getName());
     schemaValidator.validatePatchRequest(request);
@@ -149,8 +140,7 @@ public class PidController {
   @Operation(summary = "Update multiple PID Records")
   @PatchMapping(value = "/")
   public ResponseEntity<JsonApiWrapperWrite> updateRecords(@RequestBody List<JsonNode> requests,
-      Authentication authentication)
-      throws InvalidRequestException, PidResolutionException, UnprocessableEntityException {
+      Authentication authentication) {
     log.info("Validating batch update request from user {}", authentication.getName());
     for (JsonNode request : requests) {
       schemaValidator.validatePatchRequest(request);
@@ -160,13 +150,11 @@ public class PidController {
     return ResponseEntity.status(HttpStatus.OK).body(result);
   }
 
-
   @Operation(summary = "Archive given record")
   @PutMapping(value = "/{prefix}/{suffix}")
   public ResponseEntity<JsonApiWrapperWrite> archiveRecord(@PathVariable("prefix") String prefix,
       @PathVariable("suffix") String suffix, @RequestBody JsonNode request,
-      Authentication authentication)
-      throws InvalidRequestException, PidResolutionException, UnprocessableEntityException {
+      Authentication authentication) {
     log.info("Received archive request for PID {}/{} from user {}", prefix, suffix,
         authentication.getName());
     schemaValidator.validatePutRequest(request);
@@ -186,8 +174,7 @@ public class PidController {
   @Operation(summary = "rollback handle creation")
   @DeleteMapping(value = "/rollback")
   public ResponseEntity<Void> rollbackHandleCreation(@RequestBody RollbackRequest request,
-      Authentication authentication)
-      throws InvalidRequestException {
+      Authentication authentication) {
     log.info("validating rollback creation request from user {}", authentication.getName());
     var ids = request.data().stream().map(d -> d.get(NODE_ID)).toList();
     if (ids.contains(null)) {
@@ -204,8 +191,7 @@ public class PidController {
   @Operation(summary = "rollback handle update")
   @DeleteMapping(value = "/rollback/update")
   public ResponseEntity<JsonApiWrapperWrite> rollbackHandleUpdate(
-      @RequestBody List<JsonNode> requests, Authentication authentication)
-      throws InvalidRequestException, PidResolutionException, UnprocessableEntityException {
+      @RequestBody List<JsonNode> requests, Authentication authentication) {
 
     log.info("Validating rollback update request from user {}", authentication.getName());
     for (JsonNode request : requests) {
@@ -227,12 +213,10 @@ public class PidController {
     return ResponseEntity.ok().build();
   }
 
-
   @Operation(summary = "Archive multiple PID records")
   @PutMapping(value = "/")
   public ResponseEntity<JsonApiWrapperWrite> archiveRecords(@RequestBody List<JsonNode> requests,
-      Authentication authentication)
-      throws InvalidRequestException, PidResolutionException, UnprocessableEntityException {
+      Authentication authentication) {
     log.info("Validating archive request from user {}", authentication.getName());
     for (JsonNode request : requests) {
       schemaValidator.validatePutRequest(request);

--- a/src/main/java/eu/dissco/core/handlemanager/controller/RestResponseEntityExceptionHandler.java
+++ b/src/main/java/eu/dissco/core/handlemanager/controller/RestResponseEntityExceptionHandler.java
@@ -2,7 +2,6 @@ package eu.dissco.core.handlemanager.controller;
 
 import eu.dissco.core.handlemanager.exceptions.DatabaseCopyException;
 import eu.dissco.core.handlemanager.exceptions.InvalidRequestException;
-import eu.dissco.core.handlemanager.exceptions.PidCreationException;
 import eu.dissco.core.handlemanager.exceptions.PidResolutionException;
 import eu.dissco.core.handlemanager.exceptions.UnprocessableEntityException;
 import eu.dissco.core.handlemanager.responses.ExceptionResponse;
@@ -16,17 +15,9 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 @ControllerAdvice
 public class RestResponseEntityExceptionHandler extends ResponseEntityExceptionHandler {
 
-  @ResponseStatus(HttpStatus.CONFLICT)
-  @ExceptionHandler(PidCreationException.class)
-  public ResponseEntity<ExceptionResponse> pidCreationException(PidCreationException e) {
-    ExceptionResponse exceptionResponse = new ExceptionResponse(
-        String.valueOf(HttpStatus.CONFLICT), "Unable to Create PID Record", e.getMessage());
-    return ResponseEntity.status(HttpStatus.CONFLICT).body(exceptionResponse);
-  }
-
   @ResponseStatus(HttpStatus.BAD_REQUEST)
   @ExceptionHandler(InvalidRequestException.class)
-  public ResponseEntity<ExceptionResponse> invalidRecordInputException(InvalidRequestException e) {
+  public ResponseEntity<ExceptionResponse> invalidRequestException(InvalidRequestException e) {
     ExceptionResponse exceptionResponse = new ExceptionResponse(
         String.valueOf(HttpStatus.BAD_REQUEST), "Invalid Request", e.getMessage());
     return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(exceptionResponse);
@@ -53,7 +44,7 @@ public class RestResponseEntityExceptionHandler extends ResponseEntityExceptionH
   @ResponseStatus(HttpStatus.SERVICE_UNAVAILABLE)
   @ExceptionHandler(DatabaseCopyException.class)
   public ResponseEntity<ExceptionResponse> databaseCopyException(
-      UnprocessableEntityException e) {
+      DatabaseCopyException e) {
     var exceptionResponse = new ExceptionResponse(String.valueOf(HttpStatus.SERVICE_UNAVAILABLE),
         "Database Exception", e.getMessage());
     return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(exceptionResponse);

--- a/src/main/java/eu/dissco/core/handlemanager/domain/fdo/FdoProfile.java
+++ b/src/main/java/eu/dissco/core/handlemanager/domain/fdo/FdoProfile.java
@@ -1,8 +1,10 @@
 package eu.dissco.core.handlemanager.domain.fdo;
 
-import eu.dissco.core.handlemanager.exceptions.UnrecognizedFdoAttributeException;
+import eu.dissco.core.handlemanager.exceptions.InvalidRequestException;
 import java.util.Arrays;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public enum FdoProfile {
   // Kernel
   FDO_PROFILE("fdoProfile", 1),
@@ -123,8 +125,8 @@ public enum FdoProfile {
     if (fdoProfile.isPresent()) {
       return fdoProfile.get().index;
     }
-    throw new UnrecognizedFdoAttributeException(
-        "Unable to locate index for requested attribute " + searchAttribute);
+    log.error("Unable to locate index for requested attribute {}", searchAttribute);
+    throw new InvalidRequestException(searchAttribute + " not valid fdo attribute");
   }
 
 }

--- a/src/main/java/eu/dissco/core/handlemanager/domain/fdo/MediaObjectRequest.java
+++ b/src/main/java/eu/dissco/core/handlemanager/domain/fdo/MediaObjectRequest.java
@@ -85,7 +85,7 @@ public class MediaObjectRequest extends DoiRecordRequest {
       String rightsholderName,
       PrimarySpecimenObjectIdType rightsholderPidType,
       String dctermsConformsTo
-  ) throws InvalidRequestException {
+  ) {
     super(issuedForAgent, pidIssuer, StructuralType.DIGITAL,
         locations,
         referentName, FdoType.MEDIA_OBJECT.getDigitalObjectName(), primaryReferentType);
@@ -111,7 +111,7 @@ public class MediaObjectRequest extends DoiRecordRequest {
     validateRightsholder(rightsholderName, rightsholderPid);
   }
 
-  private void validateRightsholder(String name, String pid) throws InvalidRequestException {
+  private void validateRightsholder(String name, String pid) {
     if (name != null && pid == null) {
       throw new InvalidRequestException(
           "Invalid media request. Rightsholder name provided without an identifier");

--- a/src/main/java/eu/dissco/core/handlemanager/domain/validation/JsonSchemaValidator.java
+++ b/src/main/java/eu/dissco/core/handlemanager/domain/validation/JsonSchemaValidator.java
@@ -17,13 +17,10 @@ import com.networknt.schema.JsonSchema;
 import com.networknt.schema.JsonSchemaFactory;
 import com.networknt.schema.SpecVersion.VersionFlag;
 import com.networknt.schema.ValidationMessage;
-import eu.dissco.core.handlemanager.domain.fdo.FdoType;
-import eu.dissco.core.handlemanager.domain.requests.PatchRequest;
-import eu.dissco.core.handlemanager.domain.requests.PostRequest;
-import eu.dissco.core.handlemanager.domain.requests.PutRequest;
 import eu.dissco.core.handlemanager.domain.fdo.AnnotationRequest;
 import eu.dissco.core.handlemanager.domain.fdo.DigitalSpecimenRequest;
 import eu.dissco.core.handlemanager.domain.fdo.DoiRecordRequest;
+import eu.dissco.core.handlemanager.domain.fdo.FdoType;
 import eu.dissco.core.handlemanager.domain.fdo.HandleRecordRequest;
 import eu.dissco.core.handlemanager.domain.fdo.MappingRequest;
 import eu.dissco.core.handlemanager.domain.fdo.MasRequest;
@@ -31,6 +28,9 @@ import eu.dissco.core.handlemanager.domain.fdo.MediaObjectRequest;
 import eu.dissco.core.handlemanager.domain.fdo.OrganisationRequest;
 import eu.dissco.core.handlemanager.domain.fdo.SourceSystemRequest;
 import eu.dissco.core.handlemanager.domain.fdo.TombstoneRecordRequest;
+import eu.dissco.core.handlemanager.domain.requests.PatchRequest;
+import eu.dissco.core.handlemanager.domain.requests.PostRequest;
+import eu.dissco.core.handlemanager.domain.requests.PutRequest;
 import eu.dissco.core.handlemanager.exceptions.InvalidRequestException;
 import jakarta.validation.constraints.NotEmpty;
 import java.util.Arrays;
@@ -253,7 +253,7 @@ public class JsonSchemaValidator {
 
   }
 
-  public void validatePostRequest(JsonNode requestRoot) throws InvalidRequestException {
+  public void validatePostRequest(JsonNode requestRoot) {
     var validationErrors = postReqSchema.validate(requestRoot);
     if (!validationErrors.isEmpty()) {
       throw new InvalidRequestException(setErrorMessage(validationErrors, "POST"));
@@ -277,7 +277,7 @@ public class JsonSchemaValidator {
     }
   }
 
-  public void validatePatchRequest(JsonNode requestRoot) throws InvalidRequestException {
+  public void validatePatchRequest(JsonNode requestRoot) {
     var validationErrors = patchReqSchema.validate(requestRoot);
     if (!validationErrors.isEmpty()) {
       throw new InvalidRequestException(
@@ -301,7 +301,7 @@ public class JsonSchemaValidator {
     }
   }
 
-  public void validatePutRequest(JsonNode requestRoot) throws InvalidRequestException {
+  public void validatePutRequest(JsonNode requestRoot) {
     var validationErrors = putReqSchema.validate(requestRoot);
     if (!validationErrors.isEmpty()) {
       throw new InvalidRequestException(
@@ -312,8 +312,7 @@ public class JsonSchemaValidator {
   }
 
 
-  private void validateTombstoneRequestAttributes(JsonNode requestAttributes)
-      throws InvalidRequestException {
+  private void validateTombstoneRequestAttributes(JsonNode requestAttributes) {
     var validationErrors = tombstoneReqSchema.validate(requestAttributes);
     if (!validationErrors.isEmpty()) {
       throw new InvalidRequestException(
@@ -323,7 +322,7 @@ public class JsonSchemaValidator {
   }
 
   private void validateRequestAttributes(JsonNode requestAttributes, JsonSchema schema,
-      FdoType type) throws InvalidRequestException {
+      FdoType type) {
     var validationErrors = schema.validate(requestAttributes);
     if (!validationErrors.isEmpty()) {
       throw new InvalidRequestException(

--- a/src/main/java/eu/dissco/core/handlemanager/exceptions/DatabaseCopyException.java
+++ b/src/main/java/eu/dissco/core/handlemanager/exceptions/DatabaseCopyException.java
@@ -1,7 +1,8 @@
 package eu.dissco.core.handlemanager.exceptions;
 
-public class DatabaseCopyException extends Exception {
+public class DatabaseCopyException extends RuntimeException {
 
+  // Response code = 503 SERVICE UNAVAILABLE
   public DatabaseCopyException(String s) {
     super(s);
   }

--- a/src/main/java/eu/dissco/core/handlemanager/exceptions/InvalidRequestException.java
+++ b/src/main/java/eu/dissco/core/handlemanager/exceptions/InvalidRequestException.java
@@ -1,9 +1,8 @@
 package eu.dissco.core.handlemanager.exceptions;
 
-public class InvalidRequestException extends Exception {
+public class InvalidRequestException extends RuntimeException {
 
   // Response code = 400 BAD REQUEST
-
   public InvalidRequestException(String s) {
     super(s);
   }

--- a/src/main/java/eu/dissco/core/handlemanager/exceptions/PidCreationException.java
+++ b/src/main/java/eu/dissco/core/handlemanager/exceptions/PidCreationException.java
@@ -1,9 +1,0 @@
-package eu.dissco.core.handlemanager.exceptions;
-
-public class PidCreationException extends Exception {
-
-  public PidCreationException(String s) {
-    super(s);
-  }
-
-}

--- a/src/main/java/eu/dissco/core/handlemanager/exceptions/PidResolutionException.java
+++ b/src/main/java/eu/dissco/core/handlemanager/exceptions/PidResolutionException.java
@@ -1,6 +1,6 @@
 package eu.dissco.core.handlemanager.exceptions;
 
-public class PidResolutionException extends Exception {
+public class PidResolutionException extends RuntimeException {
 
   // Response code = 404 NOT FOUND
   public PidResolutionException(String s) {

--- a/src/main/java/eu/dissco/core/handlemanager/exceptions/UnprocessableEntityException.java
+++ b/src/main/java/eu/dissco/core/handlemanager/exceptions/UnprocessableEntityException.java
@@ -2,6 +2,7 @@ package eu.dissco.core.handlemanager.exceptions;
 
 public class UnprocessableEntityException extends RuntimeException {
 
+  // Response code = 422 UNPROCESSBLE ENTITY
   public UnprocessableEntityException(String s) {
     super(s);
   }

--- a/src/main/java/eu/dissco/core/handlemanager/exceptions/UnrecognizedFdoAttributeException.java
+++ b/src/main/java/eu/dissco/core/handlemanager/exceptions/UnrecognizedFdoAttributeException.java
@@ -1,6 +1,0 @@
-package eu.dissco.core.handlemanager.exceptions;
-
-public class UnrecognizedFdoAttributeException extends RuntimeException {
-  public UnrecognizedFdoAttributeException(String s) {super(s);}
-
-}

--- a/src/main/java/eu/dissco/core/handlemanager/repository/BatchInserter.java
+++ b/src/main/java/eu/dissco/core/handlemanager/repository/BatchInserter.java
@@ -20,8 +20,7 @@ public class BatchInserter {
 
   private final CopyManager copyManager;
 
-  public void batchCopy(long recordTimestamp, List<HandleAttribute> handleAttributes)
-      throws DatabaseCopyException {
+  public void batchCopy(long recordTimestamp, List<HandleAttribute> handleAttributes) {
     try (var outputStream = new ByteArrayOutputStream()) {
       for (var row : handleAttributes) {
         outputStream.write(getCsvRow(recordTimestamp, row));

--- a/src/main/java/eu/dissco/core/handlemanager/repository/PidRepository.java
+++ b/src/main/java/eu/dissco/core/handlemanager/repository/PidRepository.java
@@ -9,7 +9,6 @@ import static eu.dissco.core.handlemanager.domain.fdo.FdoProfile.PRIMARY_SPECIME
 import static org.jooq.impl.DSL.select;
 
 import eu.dissco.core.handlemanager.domain.repsitoryobjects.HandleAttribute;
-import eu.dissco.core.handlemanager.exceptions.DatabaseCopyException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -34,7 +33,7 @@ public class PidRepository {
   private final BatchInserter batchInserter;
 
   // For Handle Name Generation
-  public List<byte[]> getHandlesExist(List<byte[]> handles) {
+  public List<byte[]> getExistingHandles(List<byte[]> handles) {
     return context.selectDistinct(HANDLES.HANDLE).from(HANDLES).where(HANDLES.HANDLE.in(handles))
         .fetch().getValues(HANDLES.HANDLE, byte[].class);
   }
@@ -122,8 +121,7 @@ public class PidRepository {
   }
 
   // Post
-  public void postAttributesToDb(long recordTimestamp, List<HandleAttribute> handleAttributes)
-      throws DatabaseCopyException {
+  public void postAttributesToDb(long recordTimestamp, List<HandleAttribute> handleAttributes) {
     batchInserter.batchCopy(recordTimestamp, handleAttributes);
   }
 

--- a/src/main/java/eu/dissco/core/handlemanager/service/DoiService.java
+++ b/src/main/java/eu/dissco/core/handlemanager/service/DoiService.java
@@ -49,11 +49,17 @@ public class DoiService extends PidService {
         .map(request -> request.get(NODE_DATA).get(NODE_ATTRIBUTES)).toList();
     var type = getObjectTypeFromJsonNode(requests);
     List<HandleAttribute> handleAttributes;
-    switch (type) {
-      case DIGITAL_SPECIMEN -> handleAttributes = createDigitalSpecimen(requestAttributes, handles);
-      case MEDIA_OBJECT -> handleAttributes = createMediaObject(requestAttributes, handles);
-      default -> throw new UnsupportedOperationException(
-          type + " is not an appropriate Type for DOI endpoint.");
+    try {
+      switch (type) {
+        case DIGITAL_SPECIMEN ->
+            handleAttributes = createDigitalSpecimen(requestAttributes, handles);
+        case MEDIA_OBJECT -> handleAttributes = createMediaObject(requestAttributes, handles);
+        default -> throw new UnsupportedOperationException(
+            type + " is not an appropriate Type for DOI endpoint.");
+      }
+    } catch (JsonProcessingException e) {
+      log.error("An error has occurred in parsing request", e);
+      throw new InvalidRequestException("An error has occurred in parsing request");
     }
     log.info("Persisting new dois to db");
     pidRepository.postAttributesToDb(Instant.now().getEpochSecond(), handleAttributes);

--- a/src/main/java/eu/dissco/core/handlemanager/service/DoiService.java
+++ b/src/main/java/eu/dissco/core/handlemanager/service/DoiService.java
@@ -1,10 +1,10 @@
 package eu.dissco.core.handlemanager.service;
 
 
-import static eu.dissco.core.handlemanager.domain.jsonapi.JsonApiFields.NODE_ATTRIBUTES;
-import static eu.dissco.core.handlemanager.domain.jsonapi.JsonApiFields.NODE_DATA;
 import static eu.dissco.core.handlemanager.domain.fdo.FdoType.DIGITAL_SPECIMEN;
 import static eu.dissco.core.handlemanager.domain.fdo.FdoType.MEDIA_OBJECT;
+import static eu.dissco.core.handlemanager.domain.jsonapi.JsonApiFields.NODE_ATTRIBUTES;
+import static eu.dissco.core.handlemanager.domain.jsonapi.JsonApiFields.NODE_DATA;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -12,12 +12,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.dissco.core.handlemanager.Profiles;
 import eu.dissco.core.handlemanager.domain.datacite.DataCiteEvent;
 import eu.dissco.core.handlemanager.domain.datacite.EventType;
+import eu.dissco.core.handlemanager.domain.fdo.FdoType;
 import eu.dissco.core.handlemanager.domain.jsonapi.JsonApiWrapperWrite;
 import eu.dissco.core.handlemanager.domain.repsitoryobjects.HandleAttribute;
-import eu.dissco.core.handlemanager.domain.fdo.FdoType;
-import eu.dissco.core.handlemanager.exceptions.DatabaseCopyException;
 import eu.dissco.core.handlemanager.exceptions.InvalidRequestException;
-import eu.dissco.core.handlemanager.exceptions.PidResolutionException;
 import eu.dissco.core.handlemanager.exceptions.UnprocessableEntityException;
 import eu.dissco.core.handlemanager.properties.ProfileProperties;
 import eu.dissco.core.handlemanager.repository.PidRepository;
@@ -45,24 +43,17 @@ public class DoiService extends PidService {
   private static final String TYPE_ERROR_MESSAGE = "Error creating DOI for object of Type %s. Only Digital Specimens and Media Objects use DOIs.";
 
   @Override
-  public JsonApiWrapperWrite createRecords(List<JsonNode> requests)
-      throws InvalidRequestException, DatabaseCopyException {
+  public JsonApiWrapperWrite createRecords(List<JsonNode> requests) {
     var handles = hf.genHandleList(requests.size()).iterator();
     var requestAttributes = requests.stream()
         .map(request -> request.get(NODE_DATA).get(NODE_ATTRIBUTES)).toList();
     var type = getObjectTypeFromJsonNode(requests);
     List<HandleAttribute> handleAttributes;
-    try {
-      switch (type) {
-        case DIGITAL_SPECIMEN ->
-            handleAttributes = createDigitalSpecimen(requestAttributes, handles);
-        case MEDIA_OBJECT -> handleAttributes = createMediaObject(requestAttributes, handles);
-        default -> throw new UnsupportedOperationException(
-            type + " is not an appropriate Type for DOI endpoint.");
-      }
-    } catch (JsonProcessingException | PidResolutionException e) {
-      throw new InvalidRequestException(
-          "An error has occurred parsing a record in request. More information: " + e.getMessage());
+    switch (type) {
+      case DIGITAL_SPECIMEN -> handleAttributes = createDigitalSpecimen(requestAttributes, handles);
+      case MEDIA_OBJECT -> handleAttributes = createMediaObject(requestAttributes, handles);
+      default -> throw new UnsupportedOperationException(
+          type + " is not an appropriate Type for DOI endpoint.");
     }
     log.info("Persisting new dois to db");
     pidRepository.postAttributesToDb(Instant.now().getEpochSecond(), handleAttributes);
@@ -72,8 +63,7 @@ public class DoiService extends PidService {
   }
 
   @Override
-  public JsonApiWrapperWrite updateRecords(List<JsonNode> requests, boolean incrementVersion)
-      throws InvalidRequestException, PidResolutionException, UnprocessableEntityException {
+  public JsonApiWrapperWrite updateRecords(List<JsonNode> requests, boolean incrementVersion) {
     var type = getObjectTypeFromJsonNode(requests);
     if (!DIGITAL_SPECIMEN.equals(type) && !MEDIA_OBJECT.equals(type)) {
       throw new InvalidRequestException(TYPE_ERROR_MESSAGE);
@@ -87,7 +77,7 @@ public class DoiService extends PidService {
   }
 
   private void publishToDataCite(List<HandleAttribute> handleAttributes, EventType eventType,
-      FdoType objectType) throws UnprocessableEntityException {
+      FdoType objectType) {
     var handleMap = mapRecords(handleAttributes);
     var eventList = new ArrayList<DataCiteEvent>();
     handleMap.forEach(

--- a/src/main/java/eu/dissco/core/handlemanager/service/FdoRecordService.java
+++ b/src/main/java/eu/dissco/core/handlemanager/service/FdoRecordService.java
@@ -95,7 +95,6 @@ import eu.dissco.core.handlemanager.domain.fdo.TettrisServiceRequest;
 import eu.dissco.core.handlemanager.domain.repsitoryobjects.HandleAttribute;
 import eu.dissco.core.handlemanager.exceptions.InvalidRequestException;
 import eu.dissco.core.handlemanager.exceptions.PidResolutionException;
-import eu.dissco.core.handlemanager.exceptions.UnprocessableEntityException;
 import eu.dissco.core.handlemanager.properties.ApplicationProperties;
 import eu.dissco.core.handlemanager.properties.ProfileProperties;
 import eu.dissco.core.handlemanager.web.PidResolver;
@@ -165,8 +164,7 @@ public class FdoRecordService {
   }
 
   public List<HandleAttribute> prepareHandleRecordAttributes(HandleRecordRequest request,
-      byte[] handle, FdoType type)
-      throws InvalidRequestException, PidResolutionException {
+      byte[] handle, FdoType type) {
     List<HandleAttribute> fdoRecord = new ArrayList<>();
 
     // 100: Admin Handle
@@ -227,8 +225,7 @@ public class FdoRecordService {
     return fdoRecord;
   }
 
-  private String getObjectName(String url)
-      throws InvalidRequestException, UnprocessableEntityException, PidResolutionException {
+  private String getObjectName(String url) {
     if (url.contains(ROR_DOMAIN)) {
       return pidResolver.getObjectName(getRor(url));
     } else if (url.contains(HANDLE_DOMAIN) || url.contains(DOI_DOMAIN)) {
@@ -239,7 +236,7 @@ public class FdoRecordService {
             (ROR_DOMAIN + ", " + HANDLE_DOMAIN + ", or " + DOI_DOMAIN)));
   }
 
-  private static String getRor(String url) throws InvalidRequestException {
+  private static String getRor(String url) {
     if (!url.contains(ROR_DOMAIN)) {
       throw new InvalidRequestException(String.format(PROXY_ERROR, url, ROR_DOMAIN));
     }
@@ -247,8 +244,7 @@ public class FdoRecordService {
   }
 
   public List<HandleAttribute> prepareDoiRecordAttributes(DoiRecordRequest request, byte[] handle,
-      FdoType type)
-      throws PidResolutionException, InvalidRequestException {
+      FdoType type) {
     var fdoRecord = prepareHandleRecordAttributes(request, handle, type);
 
     // 40: referentType
@@ -271,8 +267,7 @@ public class FdoRecordService {
   }
 
   public List<HandleAttribute> prepareMediaObjectAttributes(MediaObjectRequest request,
-      byte[] handle)
-      throws PidResolutionException, InvalidRequestException {
+      byte[] handle) {
     var fdoRecord = prepareDoiRecordAttributes(request, handle, FdoType.MEDIA_OBJECT);
 
     fdoRecord.add(new HandleAttribute(MEDIA_HOST, handle, request.getMediaHost()));
@@ -343,8 +338,8 @@ public class FdoRecordService {
     return fdoRecord;
   }
 
-  public List<HandleAttribute> prepareAnnotationAttributes(AnnotationRequest request, byte[] handle)
-      throws PidResolutionException, InvalidRequestException {
+  public List<HandleAttribute> prepareAnnotationAttributes(AnnotationRequest request,
+      byte[] handle) {
     var fdoRecord = prepareHandleRecordAttributes(request, handle, FdoType.ANNOTATION);
 
     // 500 TargetPid
@@ -365,8 +360,7 @@ public class FdoRecordService {
     return fdoRecord;
   }
 
-  public List<HandleAttribute> prepareMasRecordAttributes(MasRequest request, byte[] handle)
-      throws PidResolutionException, InvalidRequestException {
+  public List<HandleAttribute> prepareMasRecordAttributes(MasRequest request, byte[] handle) {
     var fdoRecord = prepareHandleRecordAttributes(request, handle, FdoType.MAS);
     fdoRecord.add(new HandleAttribute(MAS_NAME, handle, request.getMachineAnnotationServiceName()));
     return fdoRecord;
@@ -374,8 +368,7 @@ public class FdoRecordService {
 
 
   public List<HandleAttribute> prepareSourceSystemAttributes(SourceSystemRequest request,
-      byte[] handle)
-      throws UnprocessableEntityException, PidResolutionException, InvalidRequestException {
+      byte[] handle) {
     var fdoRecord = prepareHandleRecordAttributes(request, handle, FdoType.SOURCE_SYSTEM);
 
     // 600 sourceSystemName
@@ -385,8 +378,7 @@ public class FdoRecordService {
   }
 
   public List<HandleAttribute> prepareTettrisServiceAttributes(TettrisServiceRequest request,
-      byte[] handle)
-      throws InvalidRequestException, PidResolutionException {
+      byte[] handle) {
     var fdoRecord = prepareHandleRecordAttributes(request, handle, FdoType.TETTRIS_SERVICE);
     if (request.getResourceType() != null) {
       fdoRecord.add(
@@ -403,8 +395,7 @@ public class FdoRecordService {
   }
 
   public List<HandleAttribute> prepareOrganisationAttributes(OrganisationRequest request,
-      byte[] handle)
-      throws UnprocessableEntityException, PidResolutionException, InvalidRequestException {
+      byte[] handle) {
     var fdoRecord = prepareDoiRecordAttributes(request, handle, FdoType.ORGANISATION);
 
     //101 10320/loc -> must contain ROR
@@ -431,8 +422,7 @@ public class FdoRecordService {
     return fdoRecord;
   }
 
-  public List<HandleAttribute> prepareMappingAttributes(MappingRequest request, byte[] handle)
-      throws PidResolutionException, InvalidRequestException {
+  public List<HandleAttribute> prepareMappingAttributes(MappingRequest request, byte[] handle) {
     var fdoRecord = prepareHandleRecordAttributes(request, handle, MAPPING);
 
     // 700 Source Data Standard
@@ -443,8 +433,7 @@ public class FdoRecordService {
   }
 
   public List<HandleAttribute> prepareDigitalSpecimenRecordAttributes(
-      DigitalSpecimenRequest request, byte[] handle)
-      throws PidResolutionException, InvalidRequestException {
+      DigitalSpecimenRequest request, byte[] handle) {
     var fdoRecord = prepareDoiRecordAttributes(request, handle, DIGITAL_SPECIMEN);
 
     // 200: Specimen Host
@@ -576,7 +565,7 @@ public class FdoRecordService {
   }
 
   private HandleAttribute setHostName(String hostName, String hostId, byte[] handle,
-      FdoProfile targetAttribute) throws PidResolutionException {
+      FdoProfile targetAttribute) {
     if (hostName != null) {
       return new HandleAttribute(targetAttribute, handle, hostName);
     } else {
@@ -595,12 +584,11 @@ public class FdoRecordService {
   }
 
   public List<HandleAttribute> prepareUpdateAttributes(byte[] handle, JsonNode requestAttributes,
-      FdoType type)
-      throws InvalidRequestException, UnprocessableEntityException, PidResolutionException {
+      FdoType type) {
     requestAttributes = setLocationXmlFromJson(requestAttributes,
         new String(handle, StandardCharsets.UTF_8), type);
     Map<String, Object> updateRequestMap = mapper.convertValue(requestAttributes,
-        new TypeReference<Map<String, Object>>() {
+        new TypeReference<>() {
         });
 
     var updatedAttributeList = new ArrayList<>(updateRequestMap.entrySet().stream()
@@ -614,8 +602,7 @@ public class FdoRecordService {
   }
 
   private List<HandleAttribute> addResolvedNames(Map<String, Object> updateRequestMap,
-      byte[] handle)
-      throws UnprocessableEntityException, PidResolutionException, InvalidRequestException {
+      byte[] handle) {
     var resolvableKeys = updateRequestMap.entrySet()
         .stream()
         .filter(entry -> RESOLVABLE_KEYS.containsKey(entry.getKey())
@@ -641,8 +628,8 @@ public class FdoRecordService {
     return updateRequestMap.containsKey(targetName);
   }
 
-  public List<HandleAttribute> prepareTombstoneAttributes(byte[] handle, JsonNode requestAttributes)
-      throws InvalidRequestException, UnprocessableEntityException, PidResolutionException {
+  public List<HandleAttribute> prepareTombstoneAttributes(byte[] handle,
+      JsonNode requestAttributes) {
     var tombstoneAttributes = new ArrayList<>(
         prepareUpdateAttributes(handle, requestAttributes, FdoType.TOMBSTONE));
     tombstoneAttributes.add(new HandleAttribute(PID_STATUS, handle, "ARCHIVED"));
@@ -650,16 +637,14 @@ public class FdoRecordService {
     return tombstoneAttributes;
   }
 
-  private HandleAttribute genLandingPage(byte[] handle)
-      throws InvalidRequestException {
+  private HandleAttribute genLandingPage(byte[] handle) {
     var landingPage = new String[]{"Placeholder landing page"};
     var data = setLocations(landingPage, new String(handle, StandardCharsets.UTF_8),
         FdoType.TOMBSTONE);
     return new HandleAttribute(LOC.index(), handle, LOC.get(), data);
   }
 
-  private JsonNode setLocationXmlFromJson(JsonNode request, String handle, FdoType type)
-      throws InvalidRequestException {
+  private JsonNode setLocationXmlFromJson(JsonNode request, String handle, FdoType type) {
     // Format request so that the given locations array is formatted according to 10320/loc specifications
     if (request.findValue(LOC_REQUEST) == null) {
       return request;
@@ -682,8 +667,7 @@ public class FdoRecordService {
     return dt.format(Instant.now());
   }
 
-  public byte[] setLocations(String[] userLocations, String handle, FdoType type)
-      throws InvalidRequestException {
+  public byte[] setLocations(String[] userLocations, String handle, FdoType type) {
 
     DocumentBuilder documentBuilder;
     try {
@@ -708,8 +692,9 @@ public class FdoRecordService {
     try {
       return documentToString(doc).getBytes(StandardCharsets.UTF_8);
     } catch (TransformerException e) {
+      log.error("An exception has occurred parsing location data", e);
       throw new InvalidRequestException(
-          "An error has occurred parsing location data");
+          "An exception has occurred parsing location data");
     }
   }
 

--- a/src/main/java/eu/dissco/core/handlemanager/service/HandleService.java
+++ b/src/main/java/eu/dissco/core/handlemanager/service/HandleService.java
@@ -70,7 +70,7 @@ public class HandleService extends PidService {
     } catch (JsonProcessingException | PidResolutionException e) {
       log.error("An error has occurred in processing request", e);
       throw new InvalidRequestException(
-          "An error has occurred parsing a record in request. More information: " + e.getMessage());
+          "An error has occurred parsing a record in request.");
     }
     log.info("Persisting new handles to db");
     pidRepository.postAttributesToDb(Instant.now().getEpochSecond(), handleAttributes);

--- a/src/main/java/eu/dissco/core/handlemanager/service/HandleService.java
+++ b/src/main/java/eu/dissco/core/handlemanager/service/HandleService.java
@@ -19,7 +19,6 @@ import eu.dissco.core.handlemanager.domain.fdo.SourceSystemRequest;
 import eu.dissco.core.handlemanager.domain.fdo.TettrisServiceRequest;
 import eu.dissco.core.handlemanager.domain.jsonapi.JsonApiWrapperWrite;
 import eu.dissco.core.handlemanager.domain.repsitoryobjects.HandleAttribute;
-import eu.dissco.core.handlemanager.exceptions.DatabaseCopyException;
 import eu.dissco.core.handlemanager.exceptions.InvalidRequestException;
 import eu.dissco.core.handlemanager.exceptions.PidResolutionException;
 import eu.dissco.core.handlemanager.properties.ProfileProperties;
@@ -44,8 +43,7 @@ public class HandleService extends PidService {
 
   // Pid Record Creation
   @Override
-  public JsonApiWrapperWrite createRecords(List<JsonNode> requests)
-      throws InvalidRequestException, DatabaseCopyException {
+  public JsonApiWrapperWrite createRecords(List<JsonNode> requests) {
     var handles = hf.genHandleList(requests.size()).iterator();
     var requestAttributes = requests.stream()
         .map(request -> request.get(NODE_DATA).get(NODE_ATTRIBUTES)).toList();
@@ -64,7 +62,10 @@ public class HandleService extends PidService {
         case ORGANISATION -> handleAttributes = createOrganisation(requestAttributes, handles);
         case SOURCE_SYSTEM -> handleAttributes = createSourceSystem(requestAttributes, handles);
         case TETTRIS_SERVICE -> handleAttributes = createTettrisService(requestAttributes, handles);
-        default -> throw new UnsupportedOperationException("Unrecognized type");
+        default -> {
+          log.error("Unrecognized type: {}", type);
+          throw new UnsupportedOperationException("Unrecognized type: " + type);
+        }
       }
     } catch (JsonProcessingException | PidResolutionException e) {
       log.error("An error has occurred in processing request", e);
@@ -78,7 +79,7 @@ public class HandleService extends PidService {
 
   private List<HandleAttribute> createAnnotation(List<JsonNode> requestAttributes,
       Iterator<byte[]> handleIterator)
-      throws InvalidRequestException, JsonProcessingException, PidResolutionException {
+      throws JsonProcessingException {
     List<HandleAttribute> handleAttributes = new ArrayList<>();
     for (var request : requestAttributes) {
       var thisHandle = handleIterator.next();
@@ -91,7 +92,7 @@ public class HandleService extends PidService {
 
   private List<HandleAttribute> createDoi(List<JsonNode> requestAttributes,
       Iterator<byte[]> handleIterator)
-      throws InvalidRequestException, JsonProcessingException, PidResolutionException {
+      throws JsonProcessingException {
     List<HandleAttribute> handleAttributes = new ArrayList<>();
     for (var request : requestAttributes) {
       var thisHandle = handleIterator.next();
@@ -105,7 +106,7 @@ public class HandleService extends PidService {
 
   private List<HandleAttribute> createHandle(List<JsonNode> requestAttributes,
       Iterator<byte[]> handleIterator)
-      throws InvalidRequestException, JsonProcessingException, PidResolutionException {
+      throws JsonProcessingException {
     List<HandleAttribute> handleAttributes = new ArrayList<>();
     for (var request : requestAttributes) {
       var thisHandle = handleIterator.next();
@@ -118,8 +119,7 @@ public class HandleService extends PidService {
   }
 
   private List<HandleAttribute> createMapping(List<JsonNode> requestAttributes,
-      Iterator<byte[]> handleIterator)
-      throws InvalidRequestException, JsonProcessingException, PidResolutionException {
+      Iterator<byte[]> handleIterator) throws JsonProcessingException {
     List<HandleAttribute> handleAttributes = new ArrayList<>();
     for (var request : requestAttributes) {
       var thisHandle = handleIterator.next();
@@ -132,7 +132,7 @@ public class HandleService extends PidService {
 
   private List<HandleAttribute> createMas(List<JsonNode> requestAttributes,
       Iterator<byte[]> handleIterator)
-      throws InvalidRequestException, JsonProcessingException, PidResolutionException {
+      throws JsonProcessingException {
     List<HandleAttribute> handleAttributes = new ArrayList<>();
     for (var request : requestAttributes) {
       var thisHandle = handleIterator.next();
@@ -146,7 +146,7 @@ public class HandleService extends PidService {
 
   private List<HandleAttribute> createOrganisation(List<JsonNode> requestAttributes,
       Iterator<byte[]> handleIterator)
-      throws InvalidRequestException, JsonProcessingException, PidResolutionException {
+      throws JsonProcessingException {
     List<HandleAttribute> handleAttributes = new ArrayList<>();
     for (var request : requestAttributes) {
       var thisHandle = handleIterator.next();
@@ -159,7 +159,7 @@ public class HandleService extends PidService {
 
   private List<HandleAttribute> createSourceSystem(List<JsonNode> requestAttributes,
       Iterator<byte[]> handleIterator)
-      throws InvalidRequestException, JsonProcessingException, PidResolutionException {
+      throws JsonProcessingException {
     List<HandleAttribute> handleAttributes = new ArrayList<>();
     for (var request : requestAttributes) {
       var thisHandle = handleIterator.next();
@@ -172,7 +172,7 @@ public class HandleService extends PidService {
 
   private List<HandleAttribute> createTettrisService(List<JsonNode> requestAttributes,
       Iterator<byte[]> handleIterator)
-      throws InvalidRequestException, JsonProcessingException, PidResolutionException {
+      throws JsonProcessingException {
     List<HandleAttribute> handleAttributes = new ArrayList<>();
     for (var request : requestAttributes) {
       var thisHandle = handleIterator.next();

--- a/src/main/java/eu/dissco/core/handlemanager/service/PidService.java
+++ b/src/main/java/eu/dissco/core/handlemanager/service/PidService.java
@@ -263,15 +263,10 @@ public abstract class PidService {
   }
 
   protected List<HandleAttribute> createDigitalSpecimen(List<JsonNode> requestAttributes,
-      Iterator<byte[]> handleIterator) {
+      Iterator<byte[]> handleIterator) throws JsonProcessingException {
     var specimenRequests = new ArrayList<DigitalSpecimenRequest>();
     for (var request : requestAttributes) {
-      try {
-        specimenRequests.add(mapper.treeToValue(request, DigitalSpecimenRequest.class));
-      } catch (JsonProcessingException e) {
-        log.error("Unable to parse request to DigitalSpecimenRequest object", e);
-        throw new InvalidRequestException("Unable to parse request");
-      }
+      specimenRequests.add(mapper.treeToValue(request, DigitalSpecimenRequest.class));
     }
     if (specimenRequests.isEmpty()) {
       return new ArrayList<>();
@@ -304,20 +299,13 @@ public abstract class PidService {
     }
   }
 
-
   protected List<HandleAttribute> createMediaObject(List<JsonNode> requestAttributes,
-      Iterator<byte[]> handleIterator) {
+      Iterator<byte[]> handleIterator) throws JsonProcessingException {
     List<HandleAttribute> handleAttributes = new ArrayList<>();
     for (var request : requestAttributes) {
       var thisHandle = handleIterator.next();
       MediaObjectRequest requestObject;
-      try {
-        requestObject = mapper.treeToValue(request, MediaObjectRequest.class);
-      } catch (JsonProcessingException e) {
-        log.error("Unable to parse request to MediaObject", e);
-        throw new InvalidRequestException("Unable to parse request");
-      }
-
+      requestObject = mapper.treeToValue(request, MediaObjectRequest.class);
       handleAttributes.addAll(
           fdoRecordService.prepareMediaObjectAttributes(requestObject, thisHandle));
     }

--- a/src/main/java/eu/dissco/core/handlemanager/web/PidResolver.java
+++ b/src/main/java/eu/dissco/core/handlemanager/web/PidResolver.java
@@ -26,8 +26,7 @@ public class PidResolver {
   private final ObjectMapper mapper;
 
   @Cacheable("pidName")
-  public String getObjectName(String pid)
-      throws PidResolutionException {
+  public String getObjectName(String pid) {
     log.info("getting Pid name for: {}", pid);
     var pidRecord = resolveExternalPid(pid);
     if (pidRecord.get("name") != null) {

--- a/src/test/java/eu/dissco/core/handlemanager/controller/PidControllerExceptionHandlerTest.java
+++ b/src/test/java/eu/dissco/core/handlemanager/controller/PidControllerExceptionHandlerTest.java
@@ -2,8 +2,8 @@ package eu.dissco.core.handlemanager.controller;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
+import eu.dissco.core.handlemanager.exceptions.DatabaseCopyException;
 import eu.dissco.core.handlemanager.exceptions.InvalidRequestException;
-import eu.dissco.core.handlemanager.exceptions.PidCreationException;
 import eu.dissco.core.handlemanager.exceptions.PidResolutionException;
 import eu.dissco.core.handlemanager.exceptions.UnprocessableEntityException;
 import eu.dissco.core.handlemanager.responses.ExceptionResponse;
@@ -25,27 +25,13 @@ class PidControllerExceptionHandlerTest {
   }
 
   @Test
-  void testPidCreationException() {
-    // Given
-    var expectedBody = new ExceptionResponse(HttpStatus.CONFLICT.toString(),
-        "Unable to Create PID Record", errorMessage);
-
-    // When
-    var result = exceptionHandler.pidCreationException(new PidCreationException(errorMessage));
-
-    // Then
-    assertThat(result.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
-    assertThat(result.getBody()).isEqualTo(expectedBody);
-  }
-
-  @Test
   void testInvalidRecordInput() {
     // Given
     var expectedBody = new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(),
         "Invalid Request", errorMessage);
 
     // When
-    var result = exceptionHandler.invalidRecordInputException(
+    var result = exceptionHandler.invalidRequestException(
         new InvalidRequestException(errorMessage));
 
     // Then
@@ -90,7 +76,7 @@ class PidControllerExceptionHandlerTest {
 
     // When
     var result = exceptionHandler.databaseCopyException(
-        new UnprocessableEntityException(errorMessage));
+        new DatabaseCopyException(errorMessage));
 
     // Then
     assertThat(result.getStatusCode()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);

--- a/src/test/java/eu/dissco/core/handlemanager/domain/FdoProfileTest.java
+++ b/src/test/java/eu/dissco/core/handlemanager/domain/FdoProfileTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertThrows;
 
 import eu.dissco.core.handlemanager.domain.fdo.FdoProfile;
-import eu.dissco.core.handlemanager.exceptions.UnrecognizedFdoAttributeException;
+import eu.dissco.core.handlemanager.exceptions.InvalidRequestException;
 import org.junit.jupiter.api.Test;
 
 class FdoProfileTest {
@@ -25,7 +25,7 @@ class FdoProfileTest {
 
   @Test
   void testUnrecognizedProperty() {
-    assertThrows(UnrecognizedFdoAttributeException.class,
+    assertThrows(InvalidRequestException.class,
         () -> FdoProfile.retrieveIndex("aaa"));
   }
 

--- a/src/test/java/eu/dissco/core/handlemanager/repository/PidRepositoryIT.java
+++ b/src/test/java/eu/dissco/core/handlemanager/repository/PidRepositoryIT.java
@@ -25,8 +25,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.BDDMockito.then;
 
 import eu.dissco.core.handlemanager.database.jooq.tables.Handles;
-import eu.dissco.core.handlemanager.domain.repsitoryobjects.HandleAttribute;
 import eu.dissco.core.handlemanager.domain.fdo.FdoType;
+import eu.dissco.core.handlemanager.domain.repsitoryobjects.HandleAttribute;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -86,7 +86,7 @@ class PidRepositoryIT extends BaseRepositoryIT {
     postAttributes(rows);
 
     // When
-    List<byte[]> collisions = pidRepository.getHandlesExist(handles);
+    List<byte[]> collisions = pidRepository.getExistingHandles(handles);
 
     // Then
     assertThat(collisions).hasSize(handles.size());
@@ -100,7 +100,7 @@ class PidRepositoryIT extends BaseRepositoryIT {
         HANDLE_ALT.getBytes(StandardCharsets.UTF_8));
 
     // When
-    List<byte[]> collisions = pidRepository.getHandlesExist(handles);
+    List<byte[]> collisions = pidRepository.getExistingHandles(handles);
 
     // Then
     assertThat(collisions).isEmpty();

--- a/src/test/java/eu/dissco/core/handlemanager/service/PidNameGeneratorServiceTest.java
+++ b/src/test/java/eu/dissco/core/handlemanager/service/PidNameGeneratorServiceTest.java
@@ -2,22 +2,27 @@ package eu.dissco.core.handlemanager.service;
 
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.PREFIX;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
 
+import eu.dissco.core.handlemanager.exceptions.InvalidRequestException;
 import eu.dissco.core.handlemanager.properties.ApplicationProperties;
 import eu.dissco.core.handlemanager.repository.PidRepository;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
 
 @ExtendWith(MockitoExtension.class)
 class PidNameGeneratorServiceTest {
@@ -39,85 +44,109 @@ class PidNameGeneratorServiceTest {
     this.pidNameGeneratorService = new PidNameGeneratorService(applicationProperties, pidRepository,
         random);
     lenient().when(applicationProperties.getMaxHandles()).thenReturn(MAX_HANDLES);
-  }
+    lenient().when(applicationProperties.getPrefix()).thenReturn(PREFIX);
 
-  @Test
-  void testSingleBatchGen() {
-    // Given
-    String expectedHandle = PREFIX + "/AAA-AAA-AAA";
-    given(random.nextInt(anyInt())).willReturn(0);
-    given(applicationProperties.getPrefix()).willReturn(PREFIX);
-
-    // When
-    String generatedHandle = new String(pidNameGeneratorService.genHandleList(1).get(0),
-        StandardCharsets.UTF_8);
-
-    // Then
-    assertThat(generatedHandle).isEqualTo(expectedHandle);
   }
 
   @Test
   void testBatchGen() {
     // Given
-    String expectedHandle1 = PREFIX + "/BBB-BBB-BBB";
-    String expectedHandle2 = PREFIX + "/ABB-BBB-BBB";
-
     given(random.nextInt(anyInt())).willReturn(0, 1);
-    given(applicationProperties.getPrefix()).willReturn(PREFIX);
+    var expected = List.of(PREFIX + "/BBB-BBB-BBB", PREFIX + "/ABB-BBB-BBB");
 
     // When
     List<byte[]> handleList = pidNameGeneratorService.genHandleList(2);
-    String generatedHandle1 = new String(handleList.get(0));
-    String generatedHandle2 = new String(handleList.get(1));
+    var result = handleList.stream().map(h -> new String(h, StandardCharsets.UTF_8));
 
     // Then
-    assertThat(generatedHandle1).isEqualTo(expectedHandle1);
-    assertThat(generatedHandle2).isEqualTo(expectedHandle2);
+    assertThat(result).isEqualTo(expected);
   }
 
   @Test
   void testInternalCollision() {
-    String expectedHandle1 = PREFIX + "/BBB-BBB-BBB";
-    String expectedHandle2 = PREFIX + "/AAA-AAA-AAA";
+    var expected = List.of(PREFIX + "/BBB-BBB-BBB", PREFIX + "/AAA-AAA-AAA");
+    when(random.nextInt(anyInt())).thenAnswer(new Answer<>() {
+      private int count = 0;
 
-    given(random.nextInt(anyInt())).willReturn(0, 0, 0, 0, 0, 0, 0, 0, 0)// First
-        .willReturn(0, 0, 0, 0, 0, 0, 0, 0, 0) // Collision
-        .willReturn(1);
+      public Object answer(InvocationOnMock invocation) {
+        count = count + 1;
+        if (count < 19) {
+          return 0;
+        }
+        return 1;
+      }
+    });
     given(applicationProperties.getPrefix()).willReturn(PREFIX);
 
     // When
     List<byte[]> handleList = pidNameGeneratorService.genHandleList(2);
-    String generatedHandle1 = new String(handleList.get(0));
-    String generatedHandle2 = new String(handleList.get(1));
+    var result = handleList.stream().map(h -> new String(h, StandardCharsets.UTF_8)).toList();
 
     // Then
-    assertThat(generatedHandle1).isEqualTo(expectedHandle1);
-    assertThat(generatedHandle2).isEqualTo(expectedHandle2);
+    assertThat(result).isEqualTo(expected);
   }
 
   @Test
   void testDbCollision() {
     // Given
-    byte[] expectedHandle1 = (PREFIX + "/BBB-BBB-BBB").getBytes(StandardCharsets.UTF_8);
-    byte[] expectedHandle2 = (PREFIX + "/ABB-BBB-BBB").getBytes(StandardCharsets.UTF_8);
+    var existingHandle = (PREFIX + "/BBB-BBB-BBB").getBytes(StandardCharsets.UTF_8);
+    var expected = List.of(PREFIX + "/AAA-AAA-AAA", PREFIX + "/CCC-CCC-CCC");
+    when(random.nextInt(anyInt())).thenAnswer(new Answer<>() {
+      private int count = 0;
 
-    List<byte[]> handleListInternalDuplicate = new ArrayList<>();
-    handleListInternalDuplicate.add(expectedHandle1);
-
-    given(random.nextInt(anyInt())).willReturn(0, 1);
-    given(pidRepository.getHandlesExist(anyList()))
-        .willReturn(handleListInternalDuplicate)
-        .willReturn(new ArrayList<>());
+      public Object answer(InvocationOnMock invocation) {
+        count = count + 1;
+        if (count < 10) {
+          return 0;
+        } else if (count < 19) {
+          return 1;
+        }
+        return 2;
+      }
+    });
     given(applicationProperties.getPrefix()).willReturn(PREFIX);
+    given(pidRepository.getExistingHandles(anyList()))
+        .willReturn(List.of(existingHandle))
+        .willReturn(Collections.emptyList());
 
     // When
-    List<byte[]> generatedHandleList = pidNameGeneratorService.genHandleList(2);
-    byte[] generatedHandle1 = generatedHandleList.get(0);
-    byte[] generatedHandle2 = generatedHandleList.get(1);
+    var handleList = pidNameGeneratorService.genHandleList(2);
+    var result = handleList.stream().map(h -> new String(h, StandardCharsets.UTF_8));
 
     // Then
-    assertThat(generatedHandle1).isEqualTo(expectedHandle1);
-    assertThat(generatedHandle2).isEqualTo(expectedHandle2);
+    assertThat(result).hasSameElementsAs(expected);
+  }
+
+  @Test
+  void testDbAndInternalCollision() {
+    // Given
+    var existingHandle = (PREFIX + "/BBB-BBB-BBB").getBytes(StandardCharsets.UTF_8);
+    var expected = List.of(PREFIX + "/AAA-AAA-AAA", PREFIX + "/CCC-CCC-CCC");
+    when(random.nextInt(anyInt())).thenAnswer(new Answer<>() {
+      private int count = 0;
+
+      public Object answer(InvocationOnMock invocation) {
+        count = count + 1;
+        if (count < 10) {
+          return 0;
+        } else if (count < 19) {
+          return 1;
+        } else if (count < 28) {
+          return 0;
+        }
+        return 2;
+      }
+    });
+    given(pidRepository.getExistingHandles(anyList()))
+        .willReturn(List.of(existingHandle))
+        .willReturn(Collections.emptyList());
+
+    // When
+    var handleList = pidNameGeneratorService.genHandleList(2);
+    var result = handleList.stream().map(h -> new String(h, StandardCharsets.UTF_8));
+
+    // Then
+    assertThat(result).hasSameElementsAs(expected);
   }
 
   @Test
@@ -127,6 +156,13 @@ class PidNameGeneratorServiceTest {
 
     // Then
     assertThat(tooFew).isEmpty();
+  }
+
+  @Test
+  void testExceedsMax() {
+    // Then
+    assertThrows(InvalidRequestException.class,
+        () -> pidNameGeneratorService.genHandleList(MAX_HANDLES + 1));
   }
 
 


### PR DESCRIPTION
- Exceptions can be made into runtime exceptions, as we just let them bubble up to the RestResponseEntityExceptionHandler
- Remove redundant exceptions
- Clean up the HandleNameGenerator and its tests