### PR TITLE
mark handles as failed

### DIFF
--- a/src/main/java/eu/dissco/core/handlemanager/controller/PidController.java
+++ b/src/main/java/eu/dissco/core/handlemanager/controller/PidController.java
@@ -167,6 +167,10 @@ public class PidController {
     return ResponseEntity.ok().build();
   }
 
+  /**
+   * @deprecated
+   */
+  @Deprecated(forRemoval = true)
   @Operation(summary = "rollback handle creation")
   @DeleteMapping(value = "/rollback/create")
   public ResponseEntity<Void> rollbackHandleCreation(@RequestBody List<String> handles,
@@ -185,6 +189,10 @@ public class PidController {
     return ResponseEntity.status(HttpStatus.OK).body(service.updateRecords(requests, false));
   }
 
+  /**
+   * @deprecated
+   */
+  @Deprecated(forRemoval = true)
   @Operation(summary = "rollback handle creation")
   @DeleteMapping(value = "/rollback/physId")
   public ResponseEntity<Void> rollbackHandlePhysId(

--- a/src/main/java/eu/dissco/core/handlemanager/controller/PidController.java
+++ b/src/main/java/eu/dissco/core/handlemanager/controller/PidController.java
@@ -167,6 +167,15 @@ public class PidController {
     return ResponseEntity.ok().build();
   }
 
+  @Operation(summary = "rollback handle creation")
+  @DeleteMapping(value = "/rollback/create")
+  public ResponseEntity<Void> rollbackHandleCreation(@RequestBody List<String> handles,
+      Authentication authentication) throws InvalidRequestException {
+    log.info(RECEIVED_MSG, "batch rollback create", authentication.getName());
+    service.markHandlesAsFailed(handles);
+    return ResponseEntity.ok().build();
+  }
+
   @Operation(summary = "rollback handle update")
   @DeleteMapping(value = "/rollback/update")
   public ResponseEntity<JsonApiWrapperWrite> rollbackHandleUpdate(
@@ -176,7 +185,7 @@ public class PidController {
     return ResponseEntity.status(HttpStatus.OK).body(service.updateRecords(requests, false));
   }
 
-  @Operation(summary = "rollback handle update")
+  @Operation(summary = "rollback handle creation")
   @DeleteMapping(value = "/rollback/physId")
   public ResponseEntity<Void> rollbackHandlePhysId(
       @RequestBody List<String> physicalIds, Authentication authentication) {

--- a/src/main/java/eu/dissco/core/handlemanager/controller/PidController.java
+++ b/src/main/java/eu/dissco/core/handlemanager/controller/PidController.java
@@ -1,11 +1,9 @@
 package eu.dissco.core.handlemanager.controller;
 
 
-import com.fasterxml.jackson.databind.JsonNode;
 import eu.dissco.core.handlemanager.component.SchemaValidator;
 import eu.dissco.core.handlemanager.domain.requests.PatchRequest;
 import eu.dissco.core.handlemanager.domain.requests.PostRequest;
-import eu.dissco.core.handlemanager.domain.requests.RollbackRequest;
 import eu.dissco.core.handlemanager.domain.requests.TombstoneRequest;
 import eu.dissco.core.handlemanager.domain.responses.JsonApiWrapperRead;
 import eu.dissco.core.handlemanager.domain.responses.JsonApiWrapperWrite;
@@ -154,24 +152,6 @@ public class PidController {
   }
 
   @Operation(summary = "rollback handle creation")
-  @DeleteMapping(value = "/rollback")
-  public ResponseEntity<Void> rollbackHandleCreation(@RequestBody RollbackRequest request,
-      Authentication authentication) throws InvalidRequestException {
-    log.info(RECEIVED_MSG, "batch rollback create", authentication.getName());
-    var ids = request.data().stream().map(d -> d.get("id")).toList();
-    if (ids.contains(null)) {
-      throw new InvalidRequestException("Missing Handles (\"id\") in request");
-    }
-    var handles = ids.stream().map(JsonNode::asText).toList();
-    service.rollbackHandles(handles);
-    return ResponseEntity.ok().build();
-  }
-
-  /**
-   * @deprecated
-   */
-  @Deprecated(forRemoval = true)
-  @Operation(summary = "rollback handle creation")
   @DeleteMapping(value = "/rollback/create")
   public ResponseEntity<Void> rollbackHandleCreation(@RequestBody List<String> handles,
       Authentication authentication) throws InvalidRequestException {
@@ -187,19 +167,6 @@ public class PidController {
       throws InvalidRequestException, UnprocessableEntityException {
     log.info(RECEIVED_MSG, "batch rollback update", authentication.getName());
     return ResponseEntity.status(HttpStatus.OK).body(service.updateRecords(requests, false));
-  }
-
-  /**
-   * @deprecated
-   */
-  @Deprecated(forRemoval = true)
-  @Operation(summary = "rollback handle creation")
-  @DeleteMapping(value = "/rollback/physId")
-  public ResponseEntity<Void> rollbackHandlePhysId(
-      @RequestBody List<String> physicalIds, Authentication authentication) {
-    log.info(RECEIVED_MSG, "batch rollback (physical id)", authentication.getName());
-    service.rollbackHandlesFromPhysId(physicalIds);
-    return ResponseEntity.ok().build();
   }
 
   @Operation(summary = "Archive multiple PID records")

--- a/src/main/java/eu/dissco/core/handlemanager/repository/MongoRepository.java
+++ b/src/main/java/eu/dissco/core/handlemanager/repository/MongoRepository.java
@@ -66,16 +66,6 @@ public class MongoRepository {
     return formatResults(results);
   }
 
-  public void rollbackHandles(List<String> ids) {
-    var filter = in(ID, ids);
-    collection.deleteMany(filter);
-  }
-
-  public void rollbackHandles(String localIdField, List<String> localIds) {
-    var filter = in(localIdField, localIds);
-    collection.deleteMany(filter);
-  }
-
   private List<FdoRecord> formatResults(FindIterable<Document> results)
       throws JsonProcessingException {
     var handleRecords = new ArrayList<FdoRecord>();

--- a/src/main/java/eu/dissco/core/handlemanager/service/DoiService.java
+++ b/src/main/java/eu/dissco/core/handlemanager/service/DoiService.java
@@ -102,7 +102,7 @@ public class DoiService extends PidService {
   }
 
   private void publishToDataCite(List<FdoRecord> fdoRecords, EventType eventType)
-      throws UnprocessableEntityException {
+      throws UnprocessableEntityException, InvalidRequestException {
     var eventList = fdoRecords.stream()
         .map(fdoRecord -> new DataCiteEvent(jsonFormatSingleRecord(fdoRecord.attributes()),
             eventType)).toList();
@@ -113,7 +113,7 @@ public class DoiService extends PidService {
         log.error("Critical error: Unable to publish datacite event to queue", e);
         if (eventType.equals(EventType.CREATE)) {
           log.info("Rolling back handles");
-          rollbackHandles(fdoRecords.stream().map(FdoRecord::handle).toList());
+          markHandlesAsFailed(fdoRecords.stream().map(FdoRecord::handle).toList());
         }
         throw new UnprocessableEntityException("Unable to publish datacite event to queue");
       }

--- a/src/main/java/eu/dissco/core/handlemanager/service/PidService.java
+++ b/src/main/java/eu/dissco/core/handlemanager/service/PidService.java
@@ -417,15 +417,6 @@ public abstract class PidService {
     log.debug("{} marked as failed", handles);
   }
 
-  public void rollbackHandles(List<String> handles) {
-    mongoRepository.rollbackHandles(handles);
-  }
-
-  public void rollbackHandlesFromPhysId(List<String> physicalIds) {
-    mongoRepository.rollbackHandles(NORMALISED_SPECIMEN_OBJECT_ID.get(), physicalIds);
-  }
-
-
   protected List<Document> toMongoDbDocument(List<FdoRecord> fdoRecords)
       throws JsonProcessingException {
     var documentList = new ArrayList<Document>();

--- a/src/test/java/eu/dissco/core/handlemanager/controller/PidControllerTest.java
+++ b/src/test/java/eu/dissco/core/handlemanager/controller/PidControllerTest.java
@@ -307,6 +307,16 @@ class PidControllerTest {
   }
 
   @Test
+  void testMarkAsFailed() throws Exception {
+    // When
+    var result = controller.rollbackHandleCreation(List.of(HANDLE), authentication);
+
+    // Then
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+    then(service).should().markHandlesAsFailed(List.of(HANDLE));
+  }
+
+  @Test
   void testRollbackHandles() throws InvalidRequestException {
     // Given
     var dataNode1 = MAPPER.createObjectNode();

--- a/src/test/java/eu/dissco/core/handlemanager/controller/PidControllerTest.java
+++ b/src/test/java/eu/dissco/core/handlemanager/controller/PidControllerTest.java
@@ -24,11 +24,9 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import eu.dissco.core.handlemanager.Profiles;
 import eu.dissco.core.handlemanager.component.SchemaValidator;
 import eu.dissco.core.handlemanager.domain.fdo.FdoType;
-import eu.dissco.core.handlemanager.domain.requests.RollbackRequest;
 import eu.dissco.core.handlemanager.domain.responses.JsonApiWrapperWrite;
 import eu.dissco.core.handlemanager.exceptions.InvalidRequestException;
 import eu.dissco.core.handlemanager.exceptions.PidResolutionException;
@@ -314,48 +312,6 @@ class PidControllerTest {
     // Then
     assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
     then(service).should().markHandlesAsFailed(List.of(HANDLE));
-  }
-
-  @Test
-  void testRollbackHandles() throws InvalidRequestException {
-    // Given
-    var dataNode1 = MAPPER.createObjectNode();
-    dataNode1.put("id", HANDLE);
-    var dataNode2 = MAPPER.createObjectNode();
-    dataNode2.put("id", HANDLE_ALT);
-    List<JsonNode> dataNode = List.of(dataNode1, dataNode2);
-    var request = new RollbackRequest(dataNode);
-    given(authentication.getName()).willReturn("name");
-
-    // When
-    controller.rollbackHandleCreation(request, authentication);
-
-    // Then
-    then(service).should().rollbackHandles(List.of(HANDLE, HANDLE_ALT));
-  }
-
-  @Test
-  void testRollbackHandlesByPhysId() {
-    // Given
-    given(authentication.getName()).willReturn("name");
-    var physIds = List.of("a", "b");
-
-    // When
-    controller.rollbackHandlePhysId(physIds, authentication);
-
-    //Then
-    then(service).should().rollbackHandlesFromPhysId(physIds);
-  }
-
-  @Test
-  void testRollbackHandlesBadRequest() {
-    // Given
-    List<JsonNode> dataNode = List.of(MAPPER.createObjectNode());
-    var request = new RollbackRequest(dataNode);
-
-    // Then
-    assertThrowsExactly(InvalidRequestException.class,
-        () -> controller.rollbackHandleCreation(request, authentication));
   }
 
   @Test

--- a/src/test/java/eu/dissco/core/handlemanager/repository/MongoRepositoryIT.java
+++ b/src/test/java/eu/dissco/core/handlemanager/repository/MongoRepositoryIT.java
@@ -2,7 +2,6 @@ package eu.dissco.core.handlemanager.repository;
 
 
 import static com.mongodb.client.model.Filters.eq;
-import static com.mongodb.client.model.Filters.in;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.CREATED;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.HANDLE;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.HANDLE_ALT;
@@ -196,34 +195,6 @@ class MongoRepositoryIT {
 
     // Then
     assertThat(result).isEqualTo(expected);
-  }
-
-  @Test
-  void testRollbackHandles() throws Exception {
-    // Given
-    populateMongoDB();
-    var idList = List.of(HANDLE, SPECIMEN_ID, MEDIA_ID);
-
-    // When
-    repository.rollbackHandles(idList);
-    var result = collection.find(in("_id", idList));
-
-    // Then
-    assertThat(result).isEmpty();
-  }
-
-  @Test
-  void testRollbackHandlesFromPhysicalId() throws Exception {
-    // Given
-    populateMongoDB();
-
-    // When
-    repository.rollbackHandles(FdoProfile.NORMALISED_SPECIMEN_OBJECT_ID.get(),
-        List.of(NORMALISED_PRIMARY_SPECIMEN_OBJECT_ID_TESTVAL));
-    var result = collection.find(in("_id", SPECIMEN_ID));
-
-    // Then
-    assertThat(result).isEmpty();
   }
 
   @Test

--- a/src/test/java/eu/dissco/core/handlemanager/service/DoiServiceTest.java
+++ b/src/test/java/eu/dissco/core/handlemanager/service/DoiServiceTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -148,13 +149,16 @@ class DoiServiceTest {
     given(pidNameGeneratorService.generateNewHandles(1)).willReturn(Set.of(HANDLE));
     given(fdoRecordService.prepareNewDigitalSpecimenRecord(any(), any(), any())).willReturn(
         digitalSpecimen);
+    given(mongoRepository.getHandleRecords(anyList())).willReturn(List.of(digitalSpecimen));
+    given(fdoRecordService.markRecordAsFailed(any(), any())).willReturn(digitalSpecimen);
     doThrow(JsonProcessingException.class).when(dataCiteService).publishToDataCite(any(), any());
 
     // When
     assertThrows(UnprocessableEntityException.class, () -> service.createRecords(request));
 
     // Then
-    then(mongoRepository).should().rollbackHandles(List.of(HANDLE));
+    then(fdoRecordService).should().markRecordAsFailed(any(), any());
+    then(mongoRepository).should().updateHandleRecords(anyList());
   }
 
   @Test

--- a/src/test/java/eu/dissco/core/handlemanager/service/FdoRecordServiceTest.java
+++ b/src/test/java/eu/dissco/core/handlemanager/service/FdoRecordServiceTest.java
@@ -2,6 +2,7 @@ package eu.dissco.core.handlemanager.service;
 
 import static eu.dissco.core.handlemanager.domain.fdo.FdoProfile.LOC;
 import static eu.dissco.core.handlemanager.domain.fdo.FdoProfile.OTHER_SPECIMEN_IDS;
+import static eu.dissco.core.handlemanager.domain.fdo.FdoProfile.PID_STATUS;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.API_URL;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.CREATED;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.DOC_BUILDER_FACTORY;
@@ -65,6 +66,7 @@ import eu.dissco.core.handlemanager.Profiles;
 import eu.dissco.core.handlemanager.component.PidResolver;
 import eu.dissco.core.handlemanager.domain.fdo.FdoProfile;
 import eu.dissco.core.handlemanager.domain.fdo.FdoType;
+import eu.dissco.core.handlemanager.domain.fdo.PidStatus;
 import eu.dissco.core.handlemanager.domain.repsitoryobjects.FdoAttribute;
 import eu.dissco.core.handlemanager.domain.repsitoryobjects.FdoRecord;
 import eu.dissco.core.handlemanager.domain.requests.TombstoneRequestAttributes;
@@ -577,10 +579,7 @@ class FdoRecordServiceTest {
     var result = fdoRecordService.prepareTombstoneRecord(request, UPDATED, previousVersion);
 
     // Then
-    assertThat(result.attributes()).hasSameElementsAs(expected.attributes());
-    assertThat(result.primaryLocalId()).isNull();
-    assertThat(result.fdoType()).isEqualTo(expected.fdoType());
-    assertThat(result.handle()).isEqualTo(expected.handle());
+    assertThat(result).isEqualTo(expected);
   }
 
   @Test
@@ -594,10 +593,7 @@ class FdoRecordServiceTest {
     var result = fdoRecordService.prepareTombstoneRecord(request, UPDATED, previousVersion);
 
     // Then
-    assertThat(result.attributes()).hasSameElementsAs(expected.attributes());
-    assertThat(result.primaryLocalId()).isNull();
-    assertThat(result.fdoType()).isEqualTo(expected.fdoType());
-    assertThat(result.handle()).isEqualTo(expected.handle());
+    assertThat(result).isEqualTo(expected);
   }
 
   @Test
@@ -610,10 +606,25 @@ class FdoRecordServiceTest {
     var result = fdoRecordService.prepareTombstoneRecord(request, UPDATED, previousVersion);
 
     // Then
-    assertThat(result.attributes()).hasSameElementsAs(expected.attributes());
-    assertThat(result.primaryLocalId()).isNull();
-    assertThat(result.fdoType()).isEqualTo(expected.fdoType());
-    assertThat(result.handle()).isEqualTo(expected.handle());
+    assertThat(result).isEqualTo(expected);
+  }
+
+  @Test
+  void testMarkRecordAsFailed() throws Exception {
+    // Given
+    var previousVersion = givenHandleFdoRecord(HANDLE);
+    var expectedAttributes = new ArrayList<>(previousVersion.attributes());
+    expectedAttributes.set(expectedAttributes.indexOf(
+            new FdoAttribute(PID_STATUS, CREATED, PidStatus.ACTIVE)),
+        new FdoAttribute(PID_STATUS, UPDATED, PidStatus.FAILED));
+    var expected = new FdoRecord(previousVersion.handle(), previousVersion.fdoType(),
+        expectedAttributes, previousVersion.primaryLocalId());
+
+    // When
+    var result = fdoRecordService.markRecordAsFailed(previousVersion, UPDATED);
+
+    // Then
+    assertThat(result).isEqualTo(expected);
   }
 
 }

--- a/src/test/java/eu/dissco/core/handlemanager/service/HandleServiceTest.java
+++ b/src/test/java/eu/dissco/core/handlemanager/service/HandleServiceTest.java
@@ -1,6 +1,5 @@
 package eu.dissco.core.handlemanager.service;
 
-import static eu.dissco.core.handlemanager.domain.fdo.FdoProfile.NORMALISED_SPECIMEN_OBJECT_ID;
 import static eu.dissco.core.handlemanager.domain.fdo.FdoProfile.PID_STATUS;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.CREATED;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.HANDLE;
@@ -665,29 +664,6 @@ class HandleServiceTest {
 
     // When / Then
     assertThrows(UnsupportedOperationException.class, () -> service.createRecords(requests));
-  }
-
-  @Test
-  void testRollbackHandles() {
-    // Given
-
-    // When
-    service.rollbackHandles(List.of(HANDLE));
-
-    // Then
-    then(mongoRepository).should().rollbackHandles(List.of(HANDLE));
-  }
-
-  @Test
-  void testRollbackHandlesFromPhysId() {
-    // Given
-
-    // When
-    service.rollbackHandlesFromPhysId(List.of(NORMALISED_PRIMARY_SPECIMEN_OBJECT_ID_TESTVAL));
-
-    // Then
-    then(mongoRepository).should().rollbackHandles(NORMALISED_SPECIMEN_OBJECT_ID.get(),
-        List.of(NORMALISED_PRIMARY_SPECIMEN_OBJECT_ID_TESTVAL));
   }
 
   @Test

--- a/src/test/java/eu/dissco/core/handlemanager/service/HandleServiceTest.java
+++ b/src/test/java/eu/dissco/core/handlemanager/service/HandleServiceTest.java
@@ -51,6 +51,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mockStatic;
@@ -683,6 +684,21 @@ class HandleServiceTest {
 
     // Then
     assertThat(e.getMessage()).contains(HANDLE);
+  }
+
+  @Test
+  void testMarkHandlesAsFailed() throws Exception {
+    // Given
+    var fdoRecord = givenHandleFdoRecord(HANDLE);
+    var expected = givenMongoDocument(fdoRecord);
+    given(mongoRepository.getHandleRecords(List.of(HANDLE))).willReturn(List.of(fdoRecord));
+    given(fdoRecordService.markRecordAsFailed(eq(fdoRecord), any())).willReturn(fdoRecord);
+
+    // When
+    service.markHandlesAsFailed(List.of(HANDLE));
+
+    // Then
+    then(mongoRepository).should().updateHandleRecords(List.of(expected));
   }
 
 

--- a/src/test/java/eu/dissco/core/handlemanager/service/HandleServiceTest.java
+++ b/src/test/java/eu/dissco/core/handlemanager/service/HandleServiceTest.java
@@ -327,10 +327,28 @@ class HandleServiceTest {
   }
 
   @Test
-  void testUpdateHandleRecordNotWritableInternalDuplicates() throws Exception {
+  void testUpdateHandleRecordNotWritableFailed() throws Exception {
     // Given
     var request = MAPPER.valueToTree(givenHandleKernelUpdated());
     var updateRequest = givenUpdateRequest(List.of(HANDLE), FdoType.HANDLE, request);
+    given(mongoRepository.getHandleRecords(List.of(HANDLE))).willReturn(
+        List.of(new FdoRecord(HANDLE, FdoType.HANDLE, List.of(
+            new FdoAttribute(PID_STATUS, CREATED, PidStatus.FAILED)
+        ), null)));
+
+    // When / Then
+    assertThrows(InvalidRequestException.class, () -> service.updateRecords(updateRequest, true));
+  }
+
+  @Test
+  void testUpdateHandleRecordNotWritableTombstoned() throws Exception {
+    // Given
+    var request = MAPPER.valueToTree(givenHandleKernelUpdated());
+    var updateRequest = givenUpdateRequest(List.of(HANDLE), FdoType.HANDLE, request);
+    given(mongoRepository.getHandleRecords(List.of(HANDLE))).willReturn(
+        List.of(new FdoRecord(HANDLE, FdoType.HANDLE, List.of(
+            new FdoAttribute(PID_STATUS, CREATED, PidStatus.TOMBSTONED)
+        ), null)));
 
     // When / Then
     assertThrows(InvalidRequestException.class, () -> service.updateRecords(updateRequest, true));


### PR DESCRIPTION
- new endpoint `/rollback/create` marks handles as failed instead of deleting them
- removes /rollback endpoint and /rollback/physid

Related prs
- media processor
- annotation processor
- specimen processor