### PR TITLE
Tombstone datacite pid

### DIFF
--- a/src/main/java/eu/dissco/core/handlemanager/domain/datacite/DataCiteTombstoneEvent.java
+++ b/src/main/java/eu/dissco/core/handlemanager/domain/datacite/DataCiteTombstoneEvent.java
@@ -1,0 +1,8 @@
+package eu.dissco.core.handlemanager.domain.datacite;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.List;
+
+public record DataCiteTombstoneEvent(String handle, List<JsonNode> dcRelatedIdentifiers) {
+
+}

--- a/src/main/java/eu/dissco/core/handlemanager/properties/KafkaPublisherProperties.java
+++ b/src/main/java/eu/dissco/core/handlemanager/properties/KafkaPublisherProperties.java
@@ -15,11 +15,11 @@ public class KafkaPublisherProperties {
 
   @NotBlank
   private String host;
-
   @NotBlank
   private String dcMediaTopic = "media-doi";
-
   @NotBlank
   private String dcSpecimenTopic = "specimen-doi";
+  @NotBlank
+  private String dcTombstoneTopic = "tombstone";
 
 }

--- a/src/main/java/eu/dissco/core/handlemanager/service/DataCiteService.java
+++ b/src/main/java/eu/dissco/core/handlemanager/service/DataCiteService.java
@@ -1,11 +1,16 @@
 package eu.dissco.core.handlemanager.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.dissco.core.handlemanager.Profiles;
 import eu.dissco.core.handlemanager.domain.datacite.DataCiteEvent;
+import eu.dissco.core.handlemanager.domain.datacite.DataCiteTombstoneEvent;
 import eu.dissco.core.handlemanager.domain.fdo.FdoType;
+import eu.dissco.core.handlemanager.domain.fdo.HasRelatedPid;
 import eu.dissco.core.handlemanager.properties.KafkaPublisherProperties;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Profile;
@@ -28,6 +33,19 @@ public class DataCiteService {
             : kafkaProperties.getDcMediaTopic();
     var message = mapper.writeValueAsString(event);
     kafkaService.sendObjectToQueue(topic, message);
+  }
+
+  public void tombstoneDataCite(String handle, List<HasRelatedPid> relatedPids)
+      throws JsonProcessingException {
+    var dcRelatedIdentifiers = new ArrayList<JsonNode>();
+    if (relatedPids != null) {
+      relatedPids.forEach(relatedPid -> dcRelatedIdentifiers.add(mapper.createObjectNode()
+          .put("relationType", "")
+          .put("relatedIdentifier", relatedPid.odsId())));
+    }
+    var message = mapper.writeValueAsString(
+        new DataCiteTombstoneEvent(handle, dcRelatedIdentifiers));
+    kafkaService.sendObjectToQueue(kafkaProperties.getDcTombstoneTopic(), message);
   }
 
 }

--- a/src/main/java/eu/dissco/core/handlemanager/service/DataCiteService.java
+++ b/src/main/java/eu/dissco/core/handlemanager/service/DataCiteService.java
@@ -40,7 +40,7 @@ public class DataCiteService {
     var dcRelatedIdentifiers = new ArrayList<JsonNode>();
     if (relatedPids != null) {
       relatedPids.forEach(relatedPid -> dcRelatedIdentifiers.add(mapper.createObjectNode()
-          .put("relationType", "")
+          .put("relationType", "HasMetadata")
           .put("relatedIdentifier", relatedPid.odsId())));
     }
     var message = mapper.writeValueAsString(

--- a/src/main/java/eu/dissco/core/handlemanager/service/DoiService.java
+++ b/src/main/java/eu/dissco/core/handlemanager/service/DoiService.java
@@ -10,6 +10,7 @@ import eu.dissco.core.handlemanager.domain.repsitoryobjects.FdoRecord;
 import eu.dissco.core.handlemanager.domain.requests.PatchRequest;
 import eu.dissco.core.handlemanager.domain.requests.PatchRequestData;
 import eu.dissco.core.handlemanager.domain.requests.PostRequest;
+import eu.dissco.core.handlemanager.domain.requests.TombstoneRequest;
 import eu.dissco.core.handlemanager.domain.responses.JsonApiWrapperWrite;
 import eu.dissco.core.handlemanager.exceptions.InvalidRequestException;
 import eu.dissco.core.handlemanager.exceptions.PidResolutionException;
@@ -99,6 +100,21 @@ public class DoiService extends PidService {
       log.error("An error has occurred processing JSON data", e);
       throw new UnprocessableEntityException("Json Processing Error");
     }
+  }
+
+  @Override
+  public JsonApiWrapperWrite tombstoneRecords(List<TombstoneRequest> requests)
+      throws InvalidRequestException {
+    var result = super.tombstoneRecords(requests);
+    for (var request : requests) {
+      try {
+        dataCiteService.tombstoneDataCite(request.data().id(),
+            request.data().attributes().getHasRelatedPID());
+      } catch (JsonProcessingException e) {
+        log.error("Unable to tombstone doi {} with datacite", request.data().id());
+      }
+    }
+    return result;
   }
 
   private void publishToDataCite(List<FdoRecord> fdoRecords, EventType eventType)

--- a/src/test/java/eu/dissco/core/handlemanager/service/DataCiteServiceTest.java
+++ b/src/test/java/eu/dissco/core/handlemanager/service/DataCiteServiceTest.java
@@ -69,12 +69,26 @@ class DataCiteServiceTest {
     // Given
     given(kafkaProperties.getDcTombstoneTopic()).willReturn("tombstone");
     var event = new DataCiteTombstoneEvent(HANDLE, List.of(MAPPER.createObjectNode()
-        .put("relationType", "")
+        .put("relationType", "HasMetadata")
         .put("relatedIdentifier", HANDLE_ALT)));
     var expected = MAPPER.writeValueAsString(event);
 
     // When
     dataCiteService.tombstoneDataCite(HANDLE, List.of(givenHasRelatedPid()));
+
+    // Then
+    then(kafkaService).should().sendObjectToQueue("tombstone", expected);
+  }
+
+  @Test
+  void testTombstoneRecordNullRelatedPids() throws Exception {
+    // Given
+    given(kafkaProperties.getDcTombstoneTopic()).willReturn("tombstone");
+    var event = new DataCiteTombstoneEvent(HANDLE, List.of());
+    var expected = MAPPER.writeValueAsString(event);
+
+    // When
+    dataCiteService.tombstoneDataCite(HANDLE, null);
 
     // Then
     then(kafkaService).should().sendObjectToQueue("tombstone", expected);

--- a/src/test/java/eu/dissco/core/handlemanager/service/DataCiteServiceTest.java
+++ b/src/test/java/eu/dissco/core/handlemanager/service/DataCiteServiceTest.java
@@ -1,15 +1,20 @@
 package eu.dissco.core.handlemanager.service;
 
+import static eu.dissco.core.handlemanager.testUtils.TestUtils.HANDLE;
+import static eu.dissco.core.handlemanager.testUtils.TestUtils.HANDLE_ALT;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.MAPPER;
+import static eu.dissco.core.handlemanager.testUtils.TestUtils.givenHasRelatedPid;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
 import eu.dissco.core.handlemanager.domain.datacite.DataCiteEvent;
+import eu.dissco.core.handlemanager.domain.datacite.DataCiteTombstoneEvent;
 import eu.dissco.core.handlemanager.domain.datacite.EventType;
 import eu.dissco.core.handlemanager.domain.fdo.FdoType;
 import eu.dissco.core.handlemanager.properties.KafkaPublisherProperties;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -59,5 +64,20 @@ class DataCiteServiceTest {
     then(kafkaService).should().sendObjectToQueue(eq(SPECIMEN_TOPIC), any());
   }
 
+  @Test
+  void testTombstoneRecord() throws Exception {
+    // Given
+    given(kafkaProperties.getDcTombstoneTopic()).willReturn("tombstone");
+    var event = new DataCiteTombstoneEvent(HANDLE, List.of(MAPPER.createObjectNode()
+        .put("relationType", "")
+        .put("relatedIdentifier", HANDLE_ALT)));
+    var expected = MAPPER.writeValueAsString(event);
+
+    // When
+    dataCiteService.tombstoneDataCite(HANDLE, List.of(givenHasRelatedPid()));
+
+    // Then
+    then(kafkaService).should().sendObjectToQueue("tombstone", expected);
+  }
 
 }

--- a/src/test/java/eu/dissco/core/handlemanager/testUtils/TestUtils.java
+++ b/src/test/java/eu/dissco/core/handlemanager/testUtils/TestUtils.java
@@ -214,7 +214,11 @@ public class TestUtils {
 
   public static TombstoneRequestAttributes givenTombstoneRecordRequestObject() {
     return new TombstoneRequestAttributes(TOMBSTONE_TEXT_TESTVAL,
-        List.of(new HasRelatedPid(HANDLE_ALT, "Media ID")));
+        List.of(givenHasRelatedPid()));
+  }
+
+  public static HasRelatedPid givenHasRelatedPid() {
+    return new HasRelatedPid(HANDLE_ALT, "Media ID");
   }
 
 


### PR DESCRIPTION
- Sends a tombstone message to data
- Relationship type `HasMetadata` was chosen as it seemed to be the most general. DataCite enforces a vocabulary on relationshipType, but we don't. It would be nice if we used their vocabulary for this field, but until we have a vocabulary ourselves, it has to be as general as possible