### PR TITLE
Feature/upsert specimen and media

### DIFF
--- a/.github/workflows/.trivyignore
+++ b/.github/workflows/.trivyignore
@@ -1,3 +1,0 @@
-# July 17
-# Spring boot needs to update its version of Apache Tomcat
-CVE-2024-34750

--- a/pom.xml
+++ b/pom.xml
@@ -311,9 +311,6 @@
             <argument>
               https://schemas.dissco.tech/schemas/fdo-profile/organisation/0.1.0/organisation-request-attributes.json
             </argument>
-            <argument>
-              https://schemas.dissco.tech/schemas/fdo-profile/organisation/0.1.0/organisation-request-attributes.json
-            </argument>
           </arguments>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -311,6 +311,9 @@
             <argument>
               https://schemas.dissco.tech/schemas/fdo-profile/organisation/0.1.0/organisation-request-attributes.json
             </argument>
+            <argument>
+              https://schemas.dissco.tech/schemas/fdo-profile/organisation/0.1.0/organisation-request-attributes.json
+            </argument>
           </arguments>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>spring-boot-starter-parent</artifactId>
     <groupId>org.springframework.boot</groupId>
     <relativePath/>
-    <version>3.3.1</version> <!-- lookup parent from repository -->
+    <version>3.3.4</version> <!-- lookup parent from repository -->
   </parent>
   <artifactId>handle-manager</artifactId>
   <version>0.0.1-SNAPSHOT</version>

--- a/src/main/java/eu/dissco/core/handlemanager/controller/PidController.java
+++ b/src/main/java/eu/dissco/core/handlemanager/controller/PidController.java
@@ -4,7 +4,6 @@ package eu.dissco.core.handlemanager.controller;
 import eu.dissco.core.handlemanager.component.SchemaValidator;
 import eu.dissco.core.handlemanager.domain.requests.PatchRequest;
 import eu.dissco.core.handlemanager.domain.requests.PostRequest;
-import eu.dissco.core.handlemanager.domain.requests.TombstoneRequest;
 import eu.dissco.core.handlemanager.domain.responses.JsonApiWrapperRead;
 import eu.dissco.core.handlemanager.domain.responses.JsonApiWrapperWrite;
 import eu.dissco.core.handlemanager.exceptions.InvalidRequestException;
@@ -138,7 +137,7 @@ public class PidController {
   @Operation(summary = "Archive given record")
   @PutMapping(value = "/{prefix}/{suffix}")
   public ResponseEntity<JsonApiWrapperWrite> archiveRecord(@PathVariable("prefix") String prefix,
-      @PathVariable("suffix") String suffix, @RequestBody TombstoneRequest request,
+      @PathVariable("suffix") String suffix, @RequestBody PatchRequest request,
       Authentication authentication) throws InvalidRequestException {
     log.info("Received tombstone request for PID {}/{} from user {}", prefix, suffix,
         authentication.getName());
@@ -183,7 +182,7 @@ public class PidController {
   @Operation(summary = "Archive multiple PID records")
   @PutMapping(value = "/")
   public ResponseEntity<JsonApiWrapperWrite> archiveRecords(
-      @RequestBody List<TombstoneRequest> requests,
+      @RequestBody List<PatchRequest> requests,
       Authentication authentication) throws InvalidRequestException {
     log.info(RECEIVED_MSG, "batch tombstone", authentication.getName());
     return ResponseEntity.status(HttpStatus.OK).body(service.tombstoneRecords(requests));

--- a/src/main/java/eu/dissco/core/handlemanager/controller/PidController.java
+++ b/src/main/java/eu/dissco/core/handlemanager/controller/PidController.java
@@ -138,7 +138,7 @@ public class PidController {
   @PutMapping(value = "/{prefix}/{suffix}")
   public ResponseEntity<JsonApiWrapperWrite> archiveRecord(@PathVariable("prefix") String prefix,
       @PathVariable("suffix") String suffix, @RequestBody PatchRequest request,
-      Authentication authentication) throws InvalidRequestException {
+      Authentication authentication) throws InvalidRequestException, UnprocessableEntityException {
     log.info("Received tombstone request for PID {}/{} from user {}", prefix, suffix,
         authentication.getName());
     var handle = (prefix + "/" + suffix);
@@ -183,7 +183,7 @@ public class PidController {
   @PutMapping(value = "/")
   public ResponseEntity<JsonApiWrapperWrite> archiveRecords(
       @RequestBody List<PatchRequest> requests,
-      Authentication authentication) throws InvalidRequestException {
+      Authentication authentication) throws InvalidRequestException, UnprocessableEntityException {
     log.info(RECEIVED_MSG, "batch tombstone", authentication.getName());
     return ResponseEntity.status(HttpStatus.OK).body(service.tombstoneRecords(requests));
   }

--- a/src/main/java/eu/dissco/core/handlemanager/domain/upsert/UpsertMediaResult.java
+++ b/src/main/java/eu/dissco/core/handlemanager/domain/upsert/UpsertMediaResult.java
@@ -1,0 +1,13 @@
+package eu.dissco.core.handlemanager.domain.upsert;
+
+import eu.dissco.core.handlemanager.domain.repsitoryobjects.FdoRecord;
+import eu.dissco.core.handlemanager.schema.DigitalMediaRequestAttributes;
+import java.util.List;
+import java.util.Map;
+
+public record UpsertMediaResult(
+    List<DigitalMediaRequestAttributes> newMediaRequests,
+    Map<DigitalMediaRequestAttributes, FdoRecord> updateMediaRequests
+) {
+
+}

--- a/src/main/java/eu/dissco/core/handlemanager/domain/upsert/UpsertSpecimenResult.java
+++ b/src/main/java/eu/dissco/core/handlemanager/domain/upsert/UpsertSpecimenResult.java
@@ -1,0 +1,13 @@
+package eu.dissco.core.handlemanager.domain.upsert;
+
+import eu.dissco.core.handlemanager.domain.repsitoryobjects.FdoRecord;
+import eu.dissco.core.handlemanager.schema.DigitalSpecimenRequestAttributes;
+import java.util.List;
+import java.util.Map;
+
+public record UpsertSpecimenResult(
+    List<DigitalSpecimenRequestAttributes> newSpecimenRequests,
+    Map<DigitalSpecimenRequestAttributes, FdoRecord> updateRequests
+) {
+
+}

--- a/src/main/java/eu/dissco/core/handlemanager/service/DoiService.java
+++ b/src/main/java/eu/dissco/core/handlemanager/service/DoiService.java
@@ -213,19 +213,19 @@ public class DoiService extends PidService {
       throws InvalidRequestException {
     var updateRequests = convertPatchRequestDataToAttributesClass(previousVersionMap,
         DoiKernelRequestAttributes.class);
-    var fdoRecords = new ArrayList<FdoRecord>();
+    var allFdoRecords = new ArrayList<FdoRecord>();
     var newFdoRecords = new ArrayList<FdoRecord>();
     var timestamp = Instant.now();
     for (var updateRequest : updateRequests.entrySet()) {
       var newVersion = fdoRecordService.prepareUpdatedDoiRecord(updateRequest.getKey(), timestamp,
           updateRequest.getValue(), incrementVersion);
-      fdoRecords.add(newVersion);
+      allFdoRecords.add(newVersion);
       if (fdoRecordsAreDifferent(newVersion, updateRequest.getValue())) {
         newFdoRecords.add(newVersion);
       }
     }
     updateDocuments(newFdoRecords);
-    return new JsonApiWrapperWrite(formatFdoRecord(fdoRecords, DOI));
+    return new JsonApiWrapperWrite(formatFdoRecord(allFdoRecords, DOI));
   }
 
 
@@ -295,38 +295,38 @@ public class DoiService extends PidService {
       Map<DigitalSpecimenRequestAttributes, FdoRecord> updateRequests, Instant timestamp,
       boolean updateVersion)
       throws InvalidRequestException {
-    var fdoRecords = new ArrayList<FdoRecord>();
+    var allFdoRecords = new ArrayList<FdoRecord>();
     var newFdoRecords = new ArrayList<FdoRecord>();
     for (var updateRequest : updateRequests.entrySet()) {
       var newVersion = fdoRecordService.prepareUpdatedDigitalSpecimenRecord(
           updateRequest.getKey(), timestamp,
           updateRequest.getValue(), updateVersion);
-      fdoRecords.add(newVersion);
+      allFdoRecords.add(newVersion);
       if (fdoRecordsAreDifferent(newVersion, updateRequest.getValue())) {
         newFdoRecords.add(newVersion);
       }
     }
     updateDocuments(newFdoRecords);
-    return fdoRecords;
+    return allFdoRecords;
   }
 
   private List<FdoRecord> updateExistingMediaRecords(
       Map<DigitalMediaRequestAttributes, FdoRecord> updateRequests, Instant timestamp,
       boolean incrementVersion)
       throws InvalidRequestException {
-    var fdoRecords = new ArrayList<FdoRecord>();
+    var allFdoRecords = new ArrayList<FdoRecord>();
     var newFdoRecords = new ArrayList<FdoRecord>();
     for (var updateRequest : updateRequests.entrySet()) {
       var newVersion = fdoRecordService.prepareUpdatedDigitalMediaRecord(
           updateRequest.getKey(), timestamp,
           updateRequest.getValue(), incrementVersion);
-      fdoRecords.add(newVersion);
+      allFdoRecords.add(newVersion);
       if (fdoRecordsAreDifferent(newVersion, updateRequest.getValue())) {
         newFdoRecords.add(newVersion);
       }
     }
     updateDocuments(newFdoRecords);
-    return fdoRecords;
+    return allFdoRecords;
   }
 
   private void updateDocuments(List<FdoRecord> fdoRecords)

--- a/src/main/java/eu/dissco/core/handlemanager/service/DoiService.java
+++ b/src/main/java/eu/dissco/core/handlemanager/service/DoiService.java
@@ -217,6 +217,7 @@ public class DoiService extends PidService {
           fdoRecordService.prepareUpdatedDoiRecord(request.getKey(), timestamp,
               request.getValue(), incrementVersion));
     }
+    updateDocuments(fdoRecords);
     return new JsonApiWrapperWrite(formatFdoRecord(fdoRecords, FdoType.DOI));
   }
 

--- a/src/main/java/eu/dissco/core/handlemanager/service/DoiService.java
+++ b/src/main/java/eu/dissco/core/handlemanager/service/DoiService.java
@@ -350,7 +350,7 @@ public class DoiService extends PidService {
       throws JsonProcessingException {
     var existingHandles = mongoRepository
         .searchByPrimaryLocalId(NORMALISED_SPECIMEN_OBJECT_ID.get(), normalisedIds)
-        .stream().filter(PidService::handlesAreActive)
+        .stream()
         .toList();
     if (!existingHandles.isEmpty()) {
       var handleMap = existingHandles.stream()

--- a/src/main/java/eu/dissco/core/handlemanager/service/DoiService.java
+++ b/src/main/java/eu/dissco/core/handlemanager/service/DoiService.java
@@ -1,7 +1,11 @@
 package eu.dissco.core.handlemanager.service;
 
 
+import static eu.dissco.core.handlemanager.domain.fdo.FdoProfile.NORMALISED_SPECIMEN_OBJECT_ID;
+import static eu.dissco.core.handlemanager.domain.fdo.FdoType.DIGITAL_SPECIMEN;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.dissco.core.handlemanager.Profiles;
 import eu.dissco.core.handlemanager.domain.datacite.DataCiteEvent;
@@ -12,12 +16,22 @@ import eu.dissco.core.handlemanager.domain.requests.PatchRequestData;
 import eu.dissco.core.handlemanager.domain.requests.PostRequest;
 import eu.dissco.core.handlemanager.domain.requests.TombstoneRequest;
 import eu.dissco.core.handlemanager.domain.responses.JsonApiWrapperWrite;
+import eu.dissco.core.handlemanager.domain.upsert.UpsertMediaResult;
+import eu.dissco.core.handlemanager.domain.upsert.UpsertSpecimenResult;
 import eu.dissco.core.handlemanager.exceptions.InvalidRequestException;
 import eu.dissco.core.handlemanager.exceptions.PidResolutionException;
 import eu.dissco.core.handlemanager.exceptions.UnprocessableEntityException;
 import eu.dissco.core.handlemanager.properties.ProfileProperties;
 import eu.dissco.core.handlemanager.repository.MongoRepository;
+import eu.dissco.core.handlemanager.schema.DigitalMediaRequestAttributes;
+import eu.dissco.core.handlemanager.schema.DigitalSpecimenRequestAttributes;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 import org.bson.Document;
 import org.springframework.context.annotation.Profile;
@@ -44,63 +58,241 @@ public class DoiService extends PidService {
   @Override
   public JsonApiWrapperWrite createRecords(List<PostRequest> requests)
       throws InvalidRequestException, UnprocessableEntityException {
-    var handles = hf.generateNewHandles(requests.size()).iterator();
     var requestAttributes = requests.stream()
         .map(request -> request.data().attributes())
         .toList();
     var fdoType = getFdoTypeFromRequest(requests.stream()
         .map(request -> request.data().type())
         .toList());
-    List<Document> fdoDocuments;
-    List<FdoRecord> fdoRecords;
     try {
       switch (fdoType) {
-        case DIGITAL_SPECIMEN -> fdoRecords = createDigitalSpecimen(requestAttributes, handles);
-        case DIGITAL_MEDIA -> fdoRecords = createDigitalMedia(requestAttributes, handles);
+        case DIGITAL_SPECIMEN -> {
+          return processDigitalSpecimenRequests(requestAttributes, true);
+        }
+        case DIGITAL_MEDIA -> {
+          return processDigitalMediaRequests(requestAttributes, true);
+        }
         default -> throw new UnsupportedOperationException(
             String.format(TYPE_ERROR_MESSAGE, fdoType.getDigitalObjectName()));
       }
-      fdoDocuments = toMongoDbDocument(fdoRecords);
     } catch (JsonProcessingException | PidResolutionException e) {
       throw new InvalidRequestException(
           "An error has occurred parsing a record in request. More information: "
               + e.getMessage());
     }
-    log.info("Persisting new DOIs to Document Store");
-    mongoRepository.postHandleRecords(fdoDocuments);
-    log.info("Publishing to DataCite");
-    publishToDataCite(fdoRecords, EventType.CREATE);
-    return new JsonApiWrapperWrite(formatFdoRecord(fdoRecords, fdoType));
   }
 
   @Override
   public JsonApiWrapperWrite updateRecords(List<PatchRequest> requests, boolean incrementVersion)
       throws InvalidRequestException, UnprocessableEntityException {
-    var updateRequestsData = requests.stream()
-        .map(PatchRequest::data).toList();
-    var fdoRecordMap = processUpdateRequest(
-        updateRequestsData.stream().map(PatchRequestData::id).toList());
+    var updateRequestsAttributes = requests.stream()
+        .map(PatchRequest::data)
+        .map(PatchRequestData::attributes)
+        .toList();
     var fdoType = getFdoTypeFromRequest(requests.stream().map(r -> r.data().type()).toList());
-    List<FdoRecord> fdoRecords;
-    List<Document> fdoDocuments;
     try {
       switch (fdoType) {
-        case DIGITAL_SPECIMEN ->
-            fdoRecords = updateDigitalSpecimen(updateRequestsData, fdoRecordMap, incrementVersion);
-        case DIGITAL_MEDIA ->
-            fdoRecords = updateDigitalMedia(updateRequestsData, fdoRecordMap, incrementVersion);
+        case DIGITAL_SPECIMEN -> {
+          return processDigitalSpecimenRequests(updateRequestsAttributes, incrementVersion);
+        }
+        case DIGITAL_MEDIA -> {
+          return processDigitalMediaRequests(updateRequestsAttributes, incrementVersion);
+        }
         default -> throw new UnsupportedOperationException(
             String.format(TYPE_ERROR_MESSAGE, fdoType.getDigitalObjectName()));
       }
-      fdoDocuments = toMongoDbDocument(fdoRecords);
-      mongoRepository.updateHandleRecords(fdoDocuments);
-      publishToDataCite(fdoRecords, EventType.UPDATE);
-      return new JsonApiWrapperWrite(formatFdoRecord(fdoRecords, fdoType));
     } catch (JsonProcessingException e) {
       log.error("An error has occurred processing JSON data", e);
       throw new UnprocessableEntityException("Json Processing Error");
     }
   }
+
+  // Upsert
+  private JsonApiWrapperWrite processDigitalSpecimenRequests(List<JsonNode> requestAttributes,
+      boolean incrementVersion)
+      throws JsonProcessingException, InvalidRequestException, UnprocessableEntityException {
+    var specimenRequests = new ArrayList<DigitalSpecimenRequestAttributes>();
+    for (var request : requestAttributes) {
+      specimenRequests.add(mapper.treeToValue(request, DigitalSpecimenRequestAttributes.class));
+    }
+    var timestamp = Instant.now();
+    var processResult = processUpsertRequestSpecimen(specimenRequests);
+    var updateRecords = updateExistingSpecimenRecords(processResult.updateRequests(), timestamp,
+        incrementVersion);
+    var newRecords = createNewSpecimens(processResult.newSpecimenRequests(), timestamp);
+    var fdoRecords = Stream.concat(updateRecords.stream(), newRecords.stream()).toList();
+    return new JsonApiWrapperWrite(formatFdoRecord(fdoRecords, DIGITAL_SPECIMEN));
+  }
+
+  protected JsonApiWrapperWrite processDigitalMediaRequests(List<JsonNode> requestAttributes,
+      boolean incrementVersion)
+      throws JsonProcessingException, InvalidRequestException, UnprocessableEntityException {
+    var mediaRequests = new ArrayList<DigitalMediaRequestAttributes>();
+    for (var request : requestAttributes) {
+      mediaRequests.add(mapper.treeToValue(request, DigitalMediaRequestAttributes.class));
+    }
+    if (mediaRequests.isEmpty()) {
+      return new JsonApiWrapperWrite(null);
+    }
+    var timestamp = Instant.now();
+    var processResult = processUpsertRequestMedia(mediaRequests);
+    var updateRecords = updateExistingMediaRecords(processResult.updateMediaRequests(), timestamp,
+        incrementVersion);
+    var newRecords = createNewMedia(processResult.newMediaRequests(), timestamp);
+    var fdoRecords = Stream.concat(updateRecords.stream(), newRecords.stream()).toList();
+    publishToDataCite(newRecords, EventType.CREATE);
+    publishToDataCite(updateRecords, EventType.UPDATE);
+    return new JsonApiWrapperWrite(formatFdoRecord(fdoRecords, DIGITAL_SPECIMEN));
+  }
+
+  private UpsertMediaResult processUpsertRequestMedia(
+      List<DigitalMediaRequestAttributes> mediaRequests) throws JsonProcessingException {
+    var existingSpecimenMap = identifyExistingRecords(mediaRequests
+        .stream()
+        .map(DigitalMediaRequestAttributes::getPrimaryMediaId)
+        .toList()
+    );
+    var newMedia = new ArrayList<DigitalMediaRequestAttributes>();
+    var updateMedia = new HashMap<DigitalMediaRequestAttributes, FdoRecord>();
+    mediaRequests.forEach(media -> {
+          if (existingSpecimenMap.containsKey(media.getPrimaryMediaId())) {
+            updateMedia.put(media, existingSpecimenMap.get(media.getPrimaryMediaId()));
+          } else {
+            newMedia.add(media);
+          }
+        }
+    );
+    return new UpsertMediaResult(newMedia, updateMedia);
+  }
+
+  private UpsertSpecimenResult processUpsertRequestSpecimen(
+      List<DigitalSpecimenRequestAttributes> specimenRequests) throws JsonProcessingException {
+    var existingSpecimenMap = identifyExistingRecords(specimenRequests
+        .stream()
+        .map(DigitalSpecimenRequestAttributes::getNormalisedPrimarySpecimenObjectId)
+        .toList()
+    );
+    var newSpecimens = new ArrayList<DigitalSpecimenRequestAttributes>();
+    var updateSpecimens = new HashMap<DigitalSpecimenRequestAttributes, FdoRecord>();
+    specimenRequests.forEach(specimen -> {
+          if (existingSpecimenMap.containsKey(specimen.getNormalisedPrimarySpecimenObjectId())) {
+            updateSpecimens.put(specimen,
+                existingSpecimenMap.get(specimen.getNormalisedPrimarySpecimenObjectId()));
+          } else {
+            newSpecimens.add(specimen);
+          }
+        }
+    );
+    return new UpsertSpecimenResult(newSpecimens, updateSpecimens);
+  }
+
+  // Create
+  private List<FdoRecord> createNewSpecimens(
+      List<DigitalSpecimenRequestAttributes> digitalSpecimenRequests, Instant timestamp)
+      throws InvalidRequestException {
+    var handleIterator = hf.generateNewHandles(digitalSpecimenRequests.size()).iterator();
+    var fdoRecords = new ArrayList<FdoRecord>();
+    for (var request : digitalSpecimenRequests) {
+      fdoRecords.add(
+          fdoRecordService.prepareNewDigitalSpecimenRecord(request, handleIterator.next(),
+              timestamp));
+    }
+    createDocuments(fdoRecords);
+    return fdoRecords;
+  }
+
+  private List<FdoRecord> createNewMedia(
+      List<DigitalMediaRequestAttributes> digitalMediaRequests, Instant timestamp)
+      throws InvalidRequestException {
+    var handleIterator = hf.generateNewHandles(digitalMediaRequests.size()).iterator();
+    var fdoRecords = new ArrayList<FdoRecord>();
+    for (var request : digitalMediaRequests) {
+      fdoRecords.add(
+          fdoRecordService.prepareNewDigitalMediaRecord(request, handleIterator.next(),
+              timestamp));
+    }
+    createDocuments(fdoRecords);
+    return fdoRecords;
+  }
+
+  private void createDocuments(List<FdoRecord> fdoRecords)
+      throws InvalidRequestException {
+    List<Document> fdoDocuments;
+    try {
+      fdoDocuments = toMongoDbDocument(fdoRecords);
+    } catch (JsonProcessingException e) {
+      log.error("An error has occurred in processing request", e);
+      throw new InvalidRequestException(
+          "An error has occurred parsing a record in request. More information: " + e.getMessage());
+    }
+    mongoRepository.postHandleRecords(fdoDocuments);
+    log.info("Successfully posted {} new specimen fdo records to database", fdoDocuments.size());
+  }
+
+  // Update
+
+  protected List<FdoRecord> updateExistingSpecimenRecords(
+      Map<DigitalSpecimenRequestAttributes, FdoRecord> updateRequests, Instant timestamp,
+      boolean updateVersion)
+      throws InvalidRequestException {
+    var fdoRecords = new ArrayList<FdoRecord>();
+    for (var updateRequest : updateRequests.entrySet()) {
+      fdoRecords.add(fdoRecordService.prepareUpdatedDigitalSpecimenRecord(
+          updateRequest.getKey(), timestamp,
+          updateRequest.getValue(), updateVersion));
+    }
+    updateDocuments(fdoRecords);
+    return fdoRecords;
+  }
+
+  private List<FdoRecord> updateExistingMediaRecords(
+      Map<DigitalMediaRequestAttributes, FdoRecord> updateRequests, Instant timestamp,
+      boolean incrementVersion)
+      throws InvalidRequestException {
+    var fdoRecords = new ArrayList<FdoRecord>();
+    for (var updateRequest : updateRequests.entrySet()) {
+      fdoRecords.add(fdoRecordService.prepareUpdatedDigitalMediaRecord(
+          updateRequest.getKey(), timestamp,
+          updateRequest.getValue(), incrementVersion));
+    }
+    updateDocuments(fdoRecords);
+    return fdoRecords;
+  }
+
+  private void updateDocuments(List<FdoRecord> fdoRecords)
+      throws InvalidRequestException {
+    List<Document> fdoDocuments;
+    try {
+      fdoDocuments = toMongoDbDocument(fdoRecords);
+    } catch (JsonProcessingException e) {
+      log.error("An error has occurred in processing request", e);
+      throw new InvalidRequestException(
+          "An error has occurred parsing a record in request. More information: " + e.getMessage());
+    }
+    mongoRepository.updateHandleRecords(fdoDocuments);
+    log.info("Successfully updated {} specimens fdo records to database", fdoDocuments.size());
+
+  }
+
+  private Map<String, FdoRecord> identifyExistingRecords(List<String> normalisedIds)
+      throws JsonProcessingException {
+    var existingHandles = mongoRepository
+        .searchByPrimaryLocalId(NORMALISED_SPECIMEN_OBJECT_ID.get(), normalisedIds)
+        .stream().filter(PidService::handlesAreActive)
+        .toList();
+    if (!existingHandles.isEmpty()) {
+      var handleMap = existingHandles.stream()
+          .collect(Collectors.toMap(
+              FdoRecord::primaryLocalId,
+              f -> f));
+      log.info(
+          "Some handles already exist. Updating the following records :{}",
+          handleMap.values().stream().map(FdoRecord::primaryLocalId).toList());
+      return handleMap;
+    }
+    return Map.of();
+  }
+
 
   @Override
   public JsonApiWrapperWrite tombstoneRecords(List<TombstoneRequest> requests)
@@ -131,6 +323,7 @@ public class DoiService extends PidService {
           log.info("Rolling back handles");
           rollbackHandles(fdoRecords.stream().map(FdoRecord::handle).toList());
         }
+        log.error("Unable to publish datacite event to queue", e);
         throw new UnprocessableEntityException("Unable to publish datacite event to queue");
       }
     }

--- a/src/main/java/eu/dissco/core/handlemanager/service/DoiService.java
+++ b/src/main/java/eu/dissco/core/handlemanager/service/DoiService.java
@@ -82,9 +82,7 @@ public class DoiService extends PidService {
             String.format(TYPE_ERROR_MESSAGE, fdoType.getDigitalObjectName()));
       }
     } catch (JsonProcessingException | PidResolutionException e) {
-      throw new InvalidRequestException(
-          "An error has occurred parsing a record in request. More information: "
-              + e.getMessage());
+      throw new InvalidRequestException(REQUEST_PROCESSING_ERR);
     }
   }
 
@@ -256,9 +254,8 @@ public class DoiService extends PidService {
     try {
       fdoDocuments = toMongoDbDocument(fdoRecords);
     } catch (JsonProcessingException e) {
-      log.error("An error has occurred in processing request", e);
-      throw new InvalidRequestException(
-          "An error has occurred parsing a record in request. More information: " + e.getMessage());
+      log.error(REQUEST_PROCESSING_ERR, e);
+      throw new InvalidRequestException(REQUEST_PROCESSING_ERR);
     }
     mongoRepository.postHandleRecords(fdoDocuments);
     log.info("Successfully posted {} new specimen fdo records to database", fdoDocuments.size());
@@ -319,9 +316,9 @@ public class DoiService extends PidService {
     try {
       fdoDocuments = toMongoDbDocument(fdoRecords);
     } catch (JsonProcessingException e) {
-      log.error("An error has occurred in processing request", e);
+      log.error(REQUEST_PROCESSING_ERR, e);
       throw new InvalidRequestException(
-          "An error has occurred parsing a record in request. More information: " + e.getMessage());
+          REQUEST_PROCESSING_ERR);
     }
     mongoRepository.updateHandleRecords(fdoDocuments);
     log.info("Successfully updated {} specimens fdo records to database", fdoDocuments.size());

--- a/src/main/java/eu/dissco/core/handlemanager/service/HandleService.java
+++ b/src/main/java/eu/dissco/core/handlemanager/service/HandleService.java
@@ -146,6 +146,7 @@ public class HandleService extends PidService {
       var newVersion =
           fdoRecordService.prepareUpdatedAnnotationRecord(updateRequest.getKey(), timestamp,
               updateRequest.getValue(), incrementVersion);
+      fdoRecords.add(newVersion);
       if (fdoRecordsAreDifferent(newVersion, updateRequest.getValue())) {
         newFdoRecords.add(newVersion);
       }

--- a/src/main/java/eu/dissco/core/handlemanager/service/HandleService.java
+++ b/src/main/java/eu/dissco/core/handlemanager/service/HandleService.java
@@ -139,19 +139,19 @@ public class HandleService extends PidService {
       boolean incrementVersion) throws InvalidRequestException {
     var updateRequests = convertPatchRequestDataToAttributesClass(previousVersionMap,
         AnnotationRequestAttributes.class);
-    List<FdoRecord> fdoRecords = new ArrayList<>();
+    List<FdoRecord> allFdoRecords = new ArrayList<>();
     List<FdoRecord> newFdoRecords = new ArrayList<>();
     var timestamp = Instant.now();
     for (var updateRequest : updateRequests.entrySet()) {
       var newVersion =
           fdoRecordService.prepareUpdatedAnnotationRecord(updateRequest.getKey(), timestamp,
               updateRequest.getValue(), incrementVersion);
-      fdoRecords.add(newVersion);
+      allFdoRecords.add(newVersion);
       if (fdoRecordsAreDifferent(newVersion, updateRequest.getValue())) {
         newFdoRecords.add(newVersion);
       }
     }
-    return Pair.of(newFdoRecords, fdoRecords);
+    return Pair.of(newFdoRecords, allFdoRecords);
   }
 
   private List<FdoRecord> createHandle(List<JsonNode> requestAttributes,
@@ -173,19 +173,19 @@ public class HandleService extends PidService {
       throws InvalidRequestException {
     var updateRequests = convertPatchRequestDataToAttributesClass(previousVersionMap,
         HandleRequestAttributes.class);
-    var fdoRecords = new ArrayList<FdoRecord>();
+    var allFdoRecords = new ArrayList<FdoRecord>();
     List<FdoRecord> newFdoRecords = new ArrayList<>();
     var timestamp = Instant.now();
     for (var updateRequest : updateRequests.entrySet()) {
       var newVersion =
           fdoRecordService.prepareUpdatedHandleRecord(updateRequest.getKey(), HANDLE, timestamp,
               updateRequest.getValue(), incrementVersion);
-      fdoRecords.add(newVersion);
+      allFdoRecords.add(newVersion);
       if (fdoRecordsAreDifferent(newVersion, updateRequest.getValue())) {
         newFdoRecords.add(newVersion);
       }
     }
-    return Pair.of(newFdoRecords, fdoRecords);
+    return Pair.of(newFdoRecords, allFdoRecords);
   }
 
   private List<FdoRecord> createDataMapping(List<JsonNode> requestAttributes,
@@ -207,19 +207,19 @@ public class HandleService extends PidService {
       throws InvalidRequestException {
     var updateRequests = convertPatchRequestDataToAttributesClass(previousVersionMap,
         DataMappingRequestAttributes.class);
-    List<FdoRecord> fdoRecords = new ArrayList<>();
+    List<FdoRecord> allFdoRecords = new ArrayList<>();
     List<FdoRecord> newFdoRecords = new ArrayList<>();
     var timestamp = Instant.now();
     for (var updateRequest : updateRequests.entrySet()) {
       var newVersion = fdoRecordService.prepareUpdatedDataMappingRecord(updateRequest.getKey(),
           timestamp,
           updateRequest.getValue(), incrementVersion);
-      fdoRecords.add(newVersion);
+      allFdoRecords.add(newVersion);
       if (fdoRecordsAreDifferent(newVersion, updateRequest.getValue())) {
         newFdoRecords.add(newVersion);
       }
     }
-    return Pair.of(newFdoRecords, fdoRecords);
+    return Pair.of(newFdoRecords, allFdoRecords);
   }
 
   private List<FdoRecord> createMas(List<JsonNode> requestAttributes,
@@ -238,7 +238,7 @@ public class HandleService extends PidService {
       Map<PatchRequestData, FdoRecord> previousVersionMap,
       boolean incrementVersion)
       throws InvalidRequestException {
-    List<FdoRecord> fdoRecords = new ArrayList<>();
+    List<FdoRecord> allFdoRecords = new ArrayList<>();
     List<FdoRecord> newFdoRecords = new ArrayList<>();
     var timestamp = Instant.now();
     var updateRequests = convertPatchRequestDataToAttributesClass(previousVersionMap,
@@ -247,12 +247,12 @@ public class HandleService extends PidService {
       var newVersion =
           fdoRecordService.prepareUpdatedMasRecord(updateRequest.getKey(), timestamp,
               updateRequest.getValue(), incrementVersion);
-      fdoRecords.add(newVersion);
+      allFdoRecords.add(newVersion);
       if (fdoRecordsAreDifferent(newVersion, updateRequest.getValue())) {
         newFdoRecords.add(newVersion);
       }
     }
-    return Pair.of(newFdoRecords, fdoRecords);
+    return Pair.of(newFdoRecords, allFdoRecords);
   }
 
   private List<FdoRecord> createOrganisation(List<JsonNode> requestAttributes,
@@ -273,18 +273,18 @@ public class HandleService extends PidService {
       boolean incrementVersion) throws InvalidRequestException {
     var updateRequests = convertPatchRequestDataToAttributesClass(previousVersionMap,
         OrganisationRequestAttributes.class);
-    List<FdoRecord> fdoRecords = new ArrayList<>();
+    List<FdoRecord> allFdoRecords = new ArrayList<>();
     List<FdoRecord> newFdoRecords = new ArrayList<>();
     var timestamp = Instant.now();
     for (var updateRequest : updateRequests.entrySet()) {
       var newVersion = fdoRecordService.prepareUpdatedOrganisationRecord(updateRequest.getKey(),
           timestamp, updateRequest.getValue(), incrementVersion);
-      fdoRecords.add(newVersion);
+      allFdoRecords.add(newVersion);
       if (fdoRecordsAreDifferent(newVersion, updateRequest.getValue())) {
         newFdoRecords.add(newVersion);
       }
     }
-    return Pair.of(newFdoRecords, fdoRecords);
+    return Pair.of(newFdoRecords, allFdoRecords);
   }
 
   private List<FdoRecord> createSourceSystem(List<JsonNode> requestAttributes,
@@ -306,19 +306,19 @@ public class HandleService extends PidService {
       throws InvalidRequestException {
     var updateRequests = convertPatchRequestDataToAttributesClass(previousVersionMap,
         SourceSystemRequestAttributes.class);
-    List<FdoRecord> fdoRecords = new ArrayList<>();
+    List<FdoRecord> allFdoRecords = new ArrayList<>();
     List<FdoRecord> newFdoRecords = new ArrayList<>();
     var timestamp = Instant.now();
     for (var updateRequest : updateRequests.entrySet()) {
       var newVersion =
           fdoRecordService.prepareUpdatedSourceSystemRecord(updateRequest.getKey(), timestamp,
               updateRequest.getValue(), incrementVersion);
-      fdoRecords.add(newVersion);
+      allFdoRecords.add(newVersion);
       if (fdoRecordsAreDifferent(newVersion, updateRequest.getValue())) {
         newFdoRecords.add(newVersion);
       }
     }
-    return Pair.of(newFdoRecords, fdoRecords);
+    return Pair.of(newFdoRecords, allFdoRecords);
   }
 
 }

--- a/src/main/java/eu/dissco/core/handlemanager/service/PidService.java
+++ b/src/main/java/eu/dissco/core/handlemanager/service/PidService.java
@@ -38,11 +38,9 @@ import eu.dissco.core.handlemanager.properties.ProfileProperties;
 import eu.dissco.core.handlemanager.repository.MongoRepository;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -243,33 +241,12 @@ public abstract class PidService {
     return !status.getValue().equals(PidStatus.TOMBSTONED.name());
   }
 
-  protected Map<String, FdoRecord> processUpdateRequest(List<String> handles)
-      throws InvalidRequestException {
-    checkInternalDuplicates(handles);
-    var previousVersions = getPreviousVersions(handles);
-    previousVersions = previousVersions.stream().filter(PidService::handlesAreActive).toList();
-    return previousVersions.stream()
-        .collect(Collectors.toMap(FdoRecord::handle, f -> f));
-  }
-
   protected FdoType getFdoTypeFromRequest(List<FdoType> fdoTypes) {
     var uniqueTypes = new HashSet<>(fdoTypes);
     if (uniqueTypes.size() != 1) {
       throw new UnsupportedOperationException("Requests must all be of the same type");
     }
     return uniqueTypes.iterator().next();
-  }
-
-  protected void checkInternalDuplicates(List<String> handles) throws InvalidRequestException {
-    Set<String> handlesToUpdate = new HashSet<>(handles);
-    if (handlesToUpdate.size() < handles.size()) {
-      Set<String> duplicateHandles = handles.stream()
-          .filter(i -> Collections.frequency(handles, i) > 1)
-          .collect(Collectors.toSet());
-      throw new InvalidRequestException(
-          "INVALID INPUT. Attempting to update the same record multiple times in one request. "
-              + "The following handles are duplicated in the request: " + duplicateHandles);
-    }
   }
 
   // Tombstone

--- a/src/main/java/eu/dissco/core/handlemanager/service/PidService.java
+++ b/src/main/java/eu/dissco/core/handlemanager/service/PidService.java
@@ -347,6 +347,9 @@ public abstract class PidService {
 
   protected static boolean fdoRecordsAreDifferent(FdoRecord newVersion, FdoRecord currentVersion) {
     var currentAttributes = currentVersion.attributes();
+    if (newVersion.attributes().size() != currentAttributes.size()) {
+      return true;
+    }
     for (var newAttribute : newVersion.attributes()) {
       if (!GENERATED_KEYS.contains(newAttribute.getIndex())) {
         var currentAttribute = getField(currentAttributes, newAttribute.getIndex());
@@ -358,5 +361,4 @@ public abstract class PidService {
     }
     return false;
   }
-
 }

--- a/src/main/java/eu/dissco/core/handlemanager/service/PidService.java
+++ b/src/main/java/eu/dissco/core/handlemanager/service/PidService.java
@@ -4,13 +4,11 @@ import static eu.dissco.core.handlemanager.domain.fdo.FdoProfile.ANNOTATION_HASH
 import static eu.dissco.core.handlemanager.domain.fdo.FdoProfile.HS_ADMIN;
 import static eu.dissco.core.handlemanager.domain.fdo.FdoProfile.LINKED_DO_PID;
 import static eu.dissco.core.handlemanager.domain.fdo.FdoProfile.NORMALISED_SPECIMEN_OBJECT_ID;
-import static eu.dissco.core.handlemanager.domain.fdo.FdoProfile.PID_STATUS;
 import static eu.dissco.core.handlemanager.domain.fdo.FdoProfile.PRIMARY_MEDIA_ID;
 import static eu.dissco.core.handlemanager.domain.fdo.FdoType.ANNOTATION;
 import static eu.dissco.core.handlemanager.domain.fdo.FdoType.DIGITAL_MEDIA;
 import static eu.dissco.core.handlemanager.domain.fdo.FdoType.DIGITAL_SPECIMEN;
 import static eu.dissco.core.handlemanager.domain.fdo.FdoType.TOMBSTONE;
-import static eu.dissco.core.handlemanager.service.ServiceUtils.getField;
 import static eu.dissco.core.handlemanager.service.ServiceUtils.toSingleton;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -19,7 +17,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import eu.dissco.core.handlemanager.domain.fdo.FdoProfile;
 import eu.dissco.core.handlemanager.domain.fdo.FdoType;
-import eu.dissco.core.handlemanager.domain.fdo.PidStatus;
 import eu.dissco.core.handlemanager.domain.repsitoryobjects.FdoAttribute;
 import eu.dissco.core.handlemanager.domain.repsitoryobjects.FdoRecord;
 import eu.dissco.core.handlemanager.domain.requests.PatchRequest;
@@ -224,11 +221,6 @@ public abstract class PidService {
   public abstract JsonApiWrapperWrite updateRecords(List<PatchRequest> requests,
       boolean incrementVersion)
       throws InvalidRequestException, UnprocessableEntityException;
-
-  protected static boolean handlesAreActive(FdoRecord fdoRecord) {
-    var status = getField(fdoRecord.attributes(), PID_STATUS);
-    return !status.getValue().equals(PidStatus.TOMBSTONED.name());
-  }
 
   protected static FdoType getFdoTypeFromRequest(List<FdoType> fdoTypes,
       Set<FdoType> validFdoTypes) {

--- a/src/main/java/eu/dissco/core/handlemanager/service/ServiceUtils.java
+++ b/src/main/java/eu/dissco/core/handlemanager/service/ServiceUtils.java
@@ -13,6 +13,15 @@ public class ServiceUtils {
   private ServiceUtils() {
   }
 
+  public static FdoAttribute getField(List<FdoAttribute> fdoAttributes, Integer targetIndex) {
+    for (var attribute : fdoAttributes) {
+      if (attribute.getIndex() == targetIndex) {
+        return attribute;
+      }
+    }
+    return null;
+  }
+
   public static FdoAttribute getField(List<FdoAttribute> fdoAttributes, FdoProfile targetField) {
     for (var attribute : fdoAttributes) {
       if (attribute.getIndex() == targetField.index()) {
@@ -23,7 +32,7 @@ public class ServiceUtils {
     throw new IllegalStateException();
   }
 
-  public static <T> Collector<T, ?, T> toSingleton() {
+  public static <T> Collector<T, ?, T> toSingle() {
     return Collectors.collectingAndThen(
         Collectors.toList(),
         list -> {

--- a/src/main/java/eu/dissco/core/handlemanager/service/ServiceUtils.java
+++ b/src/main/java/eu/dissco/core/handlemanager/service/ServiceUtils.java
@@ -3,6 +3,8 @@ package eu.dissco.core.handlemanager.service;
 import eu.dissco.core.handlemanager.domain.fdo.FdoProfile;
 import eu.dissco.core.handlemanager.domain.repsitoryobjects.FdoAttribute;
 import java.util.List;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -21,5 +23,16 @@ public class ServiceUtils {
     throw new IllegalStateException();
   }
 
+  public static <T> Collector<T, ?, T> toSingleton() {
+    return Collectors.collectingAndThen(
+        Collectors.toList(),
+        list -> {
+          if (list.size() != 1) {
+            throw new IllegalStateException();
+          }
+          return list.get(0);
+        }
+    );
+  }
 
 }

--- a/src/test/java/eu/dissco/core/handlemanager/controller/PidControllerTest.java
+++ b/src/test/java/eu/dissco/core/handlemanager/controller/PidControllerTest.java
@@ -5,7 +5,7 @@ import static eu.dissco.core.handlemanager.testUtils.TestUtils.HANDLE_ALT;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.HANDLE_DOMAIN;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.MAPPER;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.PREFIX;
-import static eu.dissco.core.handlemanager.testUtils.TestUtils.PRIMARY_SPECIMEN_OBJECT_ID_TESTVAL;
+import static eu.dissco.core.handlemanager.testUtils.TestUtils.PRIMARY_SPECIMEN_ID_TESTVAL;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.SUFFIX;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.UI_URL;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.givenDigitalMedia;
@@ -98,12 +98,12 @@ class PidControllerTest {
 
     var responseExpected = TestUtils.givenWriteResponseFull(List.of(HANDLE),
         FdoType.DIGITAL_SPECIMEN);
-    given(service.searchByPhysicalSpecimenId(PRIMARY_SPECIMEN_OBJECT_ID_TESTVAL)).willReturn(
+    given(service.searchByPhysicalSpecimenId(PRIMARY_SPECIMEN_ID_TESTVAL)).willReturn(
         responseExpected);
 
     // When
     var responseReceived = controller.searchByPrimarySpecimenObjectId(
-        PRIMARY_SPECIMEN_OBJECT_ID_TESTVAL);
+        PRIMARY_SPECIMEN_ID_TESTVAL);
 
     // Then
     assertThat(responseReceived.getStatusCode()).isEqualTo(HttpStatus.OK);
@@ -113,7 +113,7 @@ class PidControllerTest {
   @Test
   void testSearchByPhysicalIdCombined() throws Exception {
     // Given
-    String physicalId = PRIMARY_SPECIMEN_OBJECT_ID_TESTVAL;
+    String physicalId = PRIMARY_SPECIMEN_ID_TESTVAL;
     var responseExpected = TestUtils.givenWriteResponseFull(List.of(HANDLE),
         FdoType.DIGITAL_SPECIMEN);
     given(service.searchByPhysicalSpecimenId(physicalId)).willReturn(responseExpected);

--- a/src/test/java/eu/dissco/core/handlemanager/service/DoiServiceTest.java
+++ b/src/test/java/eu/dissco/core/handlemanager/service/DoiServiceTest.java
@@ -1,12 +1,17 @@
 package eu.dissco.core.handlemanager.service;
 
+import static eu.dissco.core.handlemanager.domain.fdo.FdoType.DIGITAL_MEDIA;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.CREATED;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.DOI_DOMAIN;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.HANDLE;
+import static eu.dissco.core.handlemanager.testUtils.TestUtils.HANDLE_ALT;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.HANDLE_DOMAIN;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.MAPPER;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.NORMALISED_PRIMARY_SPECIMEN_OBJECT_ID_TESTVAL;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.PRIMARY_MEDIA_ID_TESTVAL;
+import static eu.dissco.core.handlemanager.testUtils.TestUtils.PRIMARY_SPECIMEN_ID_ALT;
+import static eu.dissco.core.handlemanager.testUtils.TestUtils.genDigitalMediaAttributes;
+import static eu.dissco.core.handlemanager.testUtils.TestUtils.genDigitalSpecimenAttributes;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.givenDigitalMedia;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.givenDigitalMediaFdoRecord;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.givenDigitalMediaUpdated;
@@ -46,7 +51,7 @@ import eu.dissco.core.handlemanager.Profiles;
 import eu.dissco.core.handlemanager.domain.datacite.DataCiteEvent;
 import eu.dissco.core.handlemanager.domain.datacite.EventType;
 import eu.dissco.core.handlemanager.domain.fdo.FdoType;
-import eu.dissco.core.handlemanager.exceptions.InvalidRequestException;
+import eu.dissco.core.handlemanager.domain.repsitoryobjects.FdoRecord;
 import eu.dissco.core.handlemanager.exceptions.UnprocessableEntityException;
 import eu.dissco.core.handlemanager.properties.ProfileProperties;
 import eu.dissco.core.handlemanager.repository.MongoRepository;
@@ -171,6 +176,44 @@ class DoiServiceTest {
   }
 
   @Test
+  void testUpsertDigitalSpecimen() throws Exception {
+    // Given
+    var requests = List.of(givenPostRequest(givenDigitalSpecimen(),
+        FdoType.DIGITAL_SPECIMEN), givenPostRequest(
+        givenDigitalSpecimen().withNormalisedPrimarySpecimenObjectId(PRIMARY_SPECIMEN_ID_ALT),
+        FdoType.DIGITAL_SPECIMEN));
+    var fdoRecordNew = givenDigitalSpecimenFdoRecord(HANDLE);
+    var fdoRecordUpdate = new FdoRecord(HANDLE_ALT, FdoType.DIGITAL_SPECIMEN,
+        genDigitalSpecimenAttributes(HANDLE_ALT, CREATED), PRIMARY_SPECIMEN_ID_ALT);
+    var responseExpected = givenWriteResponseIdsOnly(List.of(fdoRecordUpdate, fdoRecordNew),
+        FdoType.DIGITAL_SPECIMEN, DOI_DOMAIN);
+    var dataCiteEventCreate = new DataCiteEvent(jsonFormatFdoRecord(fdoRecordNew.attributes()),
+        EventType.CREATE);
+    var dataCiteEventUpdate = new DataCiteEvent(jsonFormatFdoRecord(fdoRecordUpdate.attributes()),
+        EventType.UPDATE);
+    var previousVersion = givenDigitalSpecimenFdoRecord(HANDLE_ALT);
+    given(mongoRepository.searchByPrimaryLocalId(any(), anyList())).willReturn(
+        List.of(previousVersion));
+    given(pidNameGeneratorService.generateNewHandles(1)).willReturn(Set.of(HANDLE));
+    given(fdoRecordService.prepareNewDigitalSpecimenRecord(any(), any(), any())).willReturn(
+        fdoRecordNew);
+    given(fdoRecordService.prepareUpdatedDigitalSpecimenRecord(any(), any(), any(),
+        anyBoolean())).willReturn(
+        fdoRecordUpdate);
+    given(profileProperties.getDomain()).willReturn(DOI_DOMAIN);
+
+    // When
+    var responseReceived = service.createRecords(requests);
+
+    // Then
+    assertThat(responseReceived).isEqualTo(responseExpected);
+    then(dataCiteService).should().publishToDataCite(dataCiteEventCreate, FdoType.DIGITAL_SPECIMEN);
+    then(dataCiteService).should().publishToDataCite(dataCiteEventUpdate, FdoType.DIGITAL_SPECIMEN);
+    then(mongoRepository).should().postHandleRecords(any());
+    then(mongoRepository).should().updateHandleRecords(any());
+  }
+
+  @Test
   void testUpdateDigitalSpecimen() throws Exception {
     // Given
     var previousVersion = givenDigitalSpecimenFdoRecord(HANDLE);
@@ -227,13 +270,70 @@ class DoiServiceTest {
   }
 
   @Test
-  void testUpdateInvalidType() throws Exception {
+  void testUpsertDigitalMedia() throws Exception {
+    // Given
+    var altMedia = "https://123";
+    var requests = List.of(givenPostRequest(givenDigitalMedia(),
+        FdoType.DIGITAL_MEDIA), givenPostRequest(
+        givenDigitalMedia().withPrimaryMediaId(altMedia),
+        DIGITAL_MEDIA));
+    var previousVersion = new FdoRecord(HANDLE_ALT, DIGITAL_MEDIA,
+        genDigitalMediaAttributes(HANDLE_ALT, CREATED),
+        altMedia);
+    var fdoRecordUpdate = new FdoRecord(HANDLE_ALT, DIGITAL_MEDIA,
+        genDigitalMediaAttributes(HANDLE_ALT, CREATED), altMedia);
+    var fdoRecordNew = givenDigitalMediaFdoRecord(HANDLE);
+    var dataCiteEventNew = new DataCiteEvent(jsonFormatFdoRecord(fdoRecordNew.attributes()),
+        EventType.CREATE);
+    var dataCiteEventUpdate = new DataCiteEvent(
+        (jsonFormatFdoRecord(fdoRecordUpdate.attributes())),
+        EventType.UPDATE);
+    given(pidNameGeneratorService.generateNewHandles(1)).willReturn(Set.of(HANDLE));
+    given(mongoRepository.searchByPrimaryLocalId(any(), any())).willReturn(
+        List.of(previousVersion));
+    given(fdoRecordService.prepareNewDigitalMediaRecord(any(), any(), any())).willReturn(
+        fdoRecordNew);
+    given(fdoRecordService.prepareUpdatedDigitalMediaRecord(any(), any(), any(),
+        anyBoolean())).willReturn(
+        fdoRecordUpdate);
+    given(profileProperties.getDomain()).willReturn(DOI_DOMAIN);
+    var responseExpected = givenWriteResponseIdsOnly(List.of(fdoRecordUpdate, fdoRecordNew),
+        DIGITAL_MEDIA, DOI_DOMAIN);
+
+    // When
+    var responseReceived = service.createRecords(requests);
+
+    // Then
+    assertThat(responseReceived).isEqualTo(responseExpected);
+    then(mongoRepository).should().updateHandleRecords(any());
+    then(mongoRepository).should().postHandleRecords(any());
+    then(dataCiteService).should().publishToDataCite(dataCiteEventNew, FdoType.DIGITAL_MEDIA);
+    then(dataCiteService).should().publishToDataCite(dataCiteEventUpdate, FdoType.DIGITAL_MEDIA);
+
+  }
+
+  @Test
+  void testUpdateInvalidType() {
     // Given
     var updateRequest = givenUpdateRequest(List.of(HANDLE), FdoType.HANDLE,
         MAPPER.valueToTree(givenDigitalSpecimenUpdated()));
 
     // When Then
-    assertThrowsExactly(InvalidRequestException.class,
+    assertThrowsExactly(UnsupportedOperationException.class,
+        () -> service.updateRecords(updateRequest, true));
+  }
+
+  @Test
+  void testUpdateDuplicateHandles() throws Exception {
+    // Given
+    var previousVersion = givenDigitalSpecimenFdoRecord(HANDLE);
+    var request = MAPPER.valueToTree(givenDigitalSpecimenUpdated());
+    var updateRequest = givenUpdateRequest(List.of(HANDLE), FdoType.DIGITAL_SPECIMEN, request);
+    given(mongoRepository.getHandleRecords(List.of(HANDLE))).willReturn(
+        List.of(previousVersion, previousVersion));
+
+    // When / Then
+    assertThrowsExactly(UnprocessableEntityException.class,
         () -> service.updateRecords(updateRequest, true));
   }
 

--- a/src/test/java/eu/dissco/core/handlemanager/service/DoiServiceTest.java
+++ b/src/test/java/eu/dissco/core/handlemanager/service/DoiServiceTest.java
@@ -59,6 +59,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.env.Environment;
 import org.springframework.test.context.ActiveProfiles;
 
 @ExtendWith(MockitoExtension.class)
@@ -75,6 +76,8 @@ class DoiServiceTest {
   private DataCiteService dataCiteService;
   @Mock
   private MongoRepository mongoRepository;
+  @Mock
+  private Environment environment;
   private PidService service;
   private MockedStatic<Instant> mockedStatic;
   private MockedStatic<Clock> mockedClock;
@@ -83,7 +86,7 @@ class DoiServiceTest {
   void setup() {
     initTime();
     service = new DoiService(fdoRecordService, pidNameGeneratorService, MAPPER, profileProperties,
-        dataCiteService, mongoRepository);
+        dataCiteService, mongoRepository, environment);
   }
 
   private void initTime() {

--- a/src/test/java/eu/dissco/core/handlemanager/service/HandleServiceTest.java
+++ b/src/test/java/eu/dissco/core/handlemanager/service/HandleServiceTest.java
@@ -14,6 +14,8 @@ import static eu.dissco.core.handlemanager.testUtils.TestUtils.givenAnnotationUp
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.givenDataMapping;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.givenDataMappingFdoRecord;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.givenDataMappingUpdated;
+import static eu.dissco.core.handlemanager.testUtils.TestUtils.givenDigitalMediaUpdated;
+import static eu.dissco.core.handlemanager.testUtils.TestUtils.givenDigitalSpecimen;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.givenDigitalSpecimenFdoRecord;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.givenDoiKernel;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.givenHandleFdoRecord;
@@ -39,6 +41,7 @@ import static eu.dissco.core.handlemanager.testUtils.TestUtils.givenWriteRespons
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.givenWriteResponseIdsOnly;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.BDDMockito.given;
@@ -504,6 +507,27 @@ class HandleServiceTest {
     // Then
     then(mongoRepository).should().rollbackHandlesFromLocalId(NORMALISED_SPECIMEN_OBJECT_ID.get(),
         List.of(NORMALISED_PRIMARY_SPECIMEN_OBJECT_ID_TESTVAL));
+  }
+
+  @Test
+  void testCreateInvalidType() {
+    // Given
+    var request = List.of(givenPostRequest(givenDigitalSpecimen(),
+        FdoType.DIGITAL_SPECIMEN));
+
+    // When / Then
+    assertThrowsExactly(UnsupportedOperationException.class, () -> service.createRecords(request));
+  }
+
+  @Test
+  void testUpdateInvalidType() {
+    // Given
+    var request = givenUpdateRequest(List.of(HANDLE), FdoType.DIGITAL_MEDIA,
+        MAPPER.valueToTree(givenDigitalMediaUpdated()));
+
+    // When / Then
+    assertThrowsExactly(UnsupportedOperationException.class,
+        () -> service.updateRecords(request, true));
   }
 
 }

--- a/src/test/java/eu/dissco/core/handlemanager/testUtils/TestUtils.java
+++ b/src/test/java/eu/dissco/core/handlemanager/testUtils/TestUtils.java
@@ -93,9 +93,7 @@ import eu.dissco.core.handlemanager.domain.requests.PatchRequest;
 import eu.dissco.core.handlemanager.domain.requests.PatchRequestData;
 import eu.dissco.core.handlemanager.domain.requests.PostRequest;
 import eu.dissco.core.handlemanager.domain.requests.PostRequestData;
-import eu.dissco.core.handlemanager.domain.requests.TombstoneRequest;
 import eu.dissco.core.handlemanager.domain.requests.TombstoneRequestAttributes;
-import eu.dissco.core.handlemanager.domain.requests.TombstoneRequestData;
 import eu.dissco.core.handlemanager.domain.responses.JsonApiDataLinks;
 import eu.dissco.core.handlemanager.domain.responses.JsonApiLinks;
 import eu.dissco.core.handlemanager.domain.responses.JsonApiWrapperRead;
@@ -870,12 +868,12 @@ public class TestUtils {
     ))).toList();
   }
 
-  public static TombstoneRequest givenTombstoneRequest() {
-    return new TombstoneRequest(
-        new TombstoneRequestData(
+  public static PatchRequest givenTombstoneRequest() {
+    return new PatchRequest(
+        new PatchRequestData(
             HANDLE,
             FdoType.HANDLE,
-            givenTombstoneRecordRequestObject()
+            MAPPER.valueToTree(givenTombstoneRecordRequestObject())
         )
     );
   }

--- a/src/test/java/eu/dissco/core/handlemanager/testUtils/TestUtils.java
+++ b/src/test/java/eu/dissco/core/handlemanager/testUtils/TestUtils.java
@@ -189,9 +189,10 @@ public class TestUtils {
   public static final String PATH = UI_URL + HANDLE;
   public static final String ORCHESTRATION_URL = "https://orchestration.dissco.tech/api/v1";
   public static final String PTR_TYPE_DOI = "doi";
-  public static final String PRIMARY_SPECIMEN_OBJECT_ID_TESTVAL = "BOTANICAL.QRS.123";
+  public static final String PRIMARY_SPECIMEN_ID_TESTVAL = "BOTANICAL.QRS.123";
+  public static final String PRIMARY_SPECIMEN_ID_ALT = "AVES.123";
   public static final String NORMALISED_PRIMARY_SPECIMEN_OBJECT_ID_TESTVAL =
-      PRIMARY_SPECIMEN_OBJECT_ID_TESTVAL + ":" + ROR_IDENTIFIER;
+      PRIMARY_SPECIMEN_ID_TESTVAL + ":" + ROR_IDENTIFIER;
   public static final String EXTERNAL_PID = "21.T11148/d8de0819e144e4096645";
   public static final TransformerFactory TRANSFORMER_FACTORY = TransformerFactory.newInstance();
   public static final DocumentBuilderFactory DOC_BUILDER_FACTORY = DocumentBuilderFactory.newInstance();
@@ -358,7 +359,7 @@ public class TestUtils {
     fdoRecord.add(new FdoAttribute(SPECIMEN_HOST_NAME, timestamp, SPECIMEN_HOST_NAME_TESTVAL));
     // 202: primarySpecimenObjectId
     fdoRecord.add(new FdoAttribute(PRIMARY_SPECIMEN_OBJECT_ID, timestamp,
-        PRIMARY_SPECIMEN_OBJECT_ID_TESTVAL));
+        PRIMARY_SPECIMEN_ID_TESTVAL));
     // 203: primarySpecimenObjectIdType
     fdoRecord.add(new FdoAttribute(PRIMARY_SPECIMEN_OBJECT_ID_TYPE, timestamp,
         DigitalSpecimenRequestAttributes.PrimarySpecimenObjectIdType.GLOBAL.value()));
@@ -623,7 +624,7 @@ public class TestUtils {
         .withPrimaryReferentType(PRIMARY_REFERENT_TYPE_TESTVAL)
         .withSpecimenHost(SPECIMEN_HOST_TESTVAL)
         .withSpecimenHostName(SPECIMEN_HOST_NAME_TESTVAL)
-        .withPrimarySpecimenObjectId(PRIMARY_SPECIMEN_OBJECT_ID_TESTVAL)
+        .withPrimarySpecimenObjectId(PRIMARY_SPECIMEN_ID_TESTVAL)
         .withPrimarySpecimenObjectIdType(
             DigitalSpecimenRequestAttributes.PrimarySpecimenObjectIdType.GLOBAL)
         .withNormalisedPrimarySpecimenObjectId(NORMALISED_PRIMARY_SPECIMEN_OBJECT_ID_TESTVAL);


### PR DESCRIPTION
Upsert
- On create for specimen or media, check if record already exists. if record exists, update the existing record
- Do we want to check for equality in the fdo record?  

Handle vs Doi Profiles
- Moved digital specimen, digital media, and DOI logic to the doi service. 
- This will require a new deployment: https://github.com/DiSSCo/dissco-core-deployment/pull/74 

refactor updates
- Removed duplicate handle check - we already check that in the relevant processing services
- Changed the flow a bit to work with updates and upserts

tombstoning change
- If an update occurs, we update the PID status to be ACTIVE if it was already tombstoned, we log the result and go on with our day