### PR TITLE
ror v2

### DIFF
--- a/src/main/java/eu/dissco/core/handlemanager/component/PidResolver.java
+++ b/src/main/java/eu/dissco/core/handlemanager/component/PidResolver.java
@@ -97,8 +97,10 @@ public class PidResolver {
     try {
       if (rorResult.get(NAMES).isArray() && !rorResult.get(NAMES).isEmpty()) {
         for (var name : rorResult.get(NAMES)) {
-          if ("en".equals(name.get("lang").asText())) {
-            return name.get("value").asText();
+          for (var type : name.get("types")) {
+            if ("ror_display".equals(type.asText())) {
+              return name.get("value").asText();
+            }
           }
         }
         log.warn("No English names provided in ROR record. Using first name");

--- a/src/main/java/eu/dissco/core/handlemanager/service/FdoRecordService.java
+++ b/src/main/java/eu/dissco/core/handlemanager/service/FdoRecordService.java
@@ -128,7 +128,7 @@ public class FdoRecordService {
   private final Pattern xmlLocPattern = Pattern.compile("href=\"[^\"]+\"");
   public static final String HANDLE_DOMAIN = "https://hdl.handle.net/";
   public static final String DOI_DOMAIN = "https://doi.org/";
-  private static final String ROR_API_DOMAIN = "https://api.ror.org/organizations/";
+  private static final String ROR_API_DOMAIN = "https://api.ror.org/v2/organizations/";
   private static final String ROR_DOMAIN = "https://ror.org/";
   private static final String WIKIDATA_DOMAIN = "https://www.wikidata.org/wiki/";
   private static final String WIKIDATA_API = "https://wikidata.org/w/rest.php/wikibase/v0/entities/items/";
@@ -840,9 +840,9 @@ public class FdoRecordService {
       return name;
     }
     if (url.contains(ROR_DOMAIN)) {
-      return pidResolver.getObjectName(getRor(url));
+      return pidResolver.getObjectName(getRor(url), true);
     } else if (url.contains(HANDLE_DOMAIN) || url.contains(DOI_DOMAIN)) {
-      return pidResolver.getObjectName(url);
+      return pidResolver.getObjectName(url, false);
     } else if (url.contains(WIKIDATA_DOMAIN)) {
       return pidResolver.resolveQid(url.replace(WIKIDATA_DOMAIN, WIKIDATA_API));
     }

--- a/src/test/java/eu/dissco/core/handlemanager/component/PidResolverTest.java
+++ b/src/test/java/eu/dissco/core/handlemanager/component/PidResolverTest.java
@@ -1,6 +1,7 @@
 package eu.dissco.core.handlemanager.component;
 
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.EXTERNAL_PID;
+import static eu.dissco.core.handlemanager.testUtils.TestUtils.HANDLE;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.MAPPER;
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.loadResourceFile;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -48,7 +49,7 @@ class PidResolverTest {
   }
 
   @Test
-  void testResolveExternalPid() throws Exception {
+  void testResolveExternalPidHandle() throws Exception {
     // Given
     var expectedResponse = MAPPER.readTree(loadResourceFile("pidrecord/pidRecord.json"));
     var expected = expectedResponse.get("name").asText();
@@ -58,10 +59,101 @@ class PidResolverTest {
         .addHeader("Content-Type", "application/json"));
 
     // When
-    var response = pidResolver.getObjectName(EXTERNAL_PID);
+    var response = pidResolver.getObjectName(EXTERNAL_PID, false);
 
     // Then
     assertThat(response).isEqualTo(expected);
+  }
+
+  @Test
+  void testResolveRor() throws Exception {
+    var expected = "Naturalis Biodiversity Center";
+    var response = MAPPER.readTree("""
+        {
+         "names": [
+            {
+              "lang": "nl",
+              "types": [
+                "label"
+              ],
+              "value": "Nederlands Centrum voor Biodiversiteit Naturalis"
+            },
+            {
+              "lang": "en",
+              "types": [
+                "ror_display",
+                "label"
+              ],
+              "value": "Naturalis Biodiversity Center"
+            }
+            ]
+        }
+        """);
+    mockServer.enqueue(new MockResponse()
+        .setBody(MAPPER.writeValueAsString(response))
+        .setResponseCode(HttpStatus.OK.value())
+        .addHeader("Content-Type", "application/json"));
+
+    // When
+    var result = pidResolver.getObjectName(HANDLE, true);
+
+    // Then
+    assertThat(result).isEqualTo(expected);
+  }
+
+  @Test
+  void testResolveRorNoEnglish() throws Exception {
+    var expected = "Nederlands Centrum voor Biodiversiteit Naturalis";
+    var response = MAPPER.readTree("""
+        {
+         "names": [
+            {
+              "lang": "nl",
+              "types": [
+                "label"
+              ],
+              "value": "Nederlands Centrum voor Biodiversiteit Naturalis"
+            }
+            ]
+        }
+        """);
+    mockServer.enqueue(new MockResponse()
+        .setBody(MAPPER.writeValueAsString(response))
+        .setResponseCode(HttpStatus.OK.value())
+        .addHeader("Content-Type", "application/json"));
+
+    // When
+    var result = pidResolver.getObjectName(HANDLE, true);
+
+    // Then
+    assertThat(result).isEqualTo(expected);
+  }
+
+  @Test
+  void testResolveRorUnexpected() throws Exception {
+    var response = MAPPER.readTree("""
+        {
+         "names": [
+            {
+              "language": "nl",
+              "types": [
+                "label"
+              ],
+              "value": "Nederlands Centrum voor Biodiversiteit Naturalis"
+            }
+            ]
+        }
+        """);
+    mockServer.enqueue(new MockResponse()
+        .setBody(MAPPER.writeValueAsString(response))
+        .setResponseCode(HttpStatus.OK.value())
+        .addHeader("Content-Type", "application/json"));
+
+    // When
+    var result = pidResolver.getObjectName(HANDLE, true);
+
+    // Then
+    assertThat(result).isNull();
   }
 
   @Test
@@ -124,7 +216,7 @@ class PidResolverTest {
   }
 
   @Test
-  void testResolveExternalPidNoName() throws Exception {
+  void testResolveExternalPidNoNameHandle() throws Exception {
     // Given
     var expectedResponse = MAPPER.readTree(loadResourceFile("pidrecord/pidRecordNoName.json"));
     var expected = "";
@@ -134,21 +226,21 @@ class PidResolverTest {
         .addHeader("Content-Type", "application/json"));
 
     // When
-    var response = pidResolver.getObjectName(EXTERNAL_PID);
+    var response = pidResolver.getObjectName(EXTERNAL_PID, false);
 
     // Then
     assertThat(response).isEqualTo(expected);
   }
 
   @Test
-  void testResolveExternalPidNotFound() throws Exception {
+  void testResolveExternalPidNotFoundHandle() throws Exception {
     // Given
     mockServer.enqueue(new MockResponse()
         .setResponseCode(HttpStatus.NOT_FOUND.value())
         .addHeader("Content-Type", "application/json"));
 
     // When
-    var response = pidResolver.getObjectName(EXTERNAL_PID);
+    var response = pidResolver.getObjectName(EXTERNAL_PID, false);
 
     // Then
     assertThat(response).isEqualTo("NOT FOUND");
@@ -162,12 +254,12 @@ class PidResolverTest {
         .addHeader("Content-Type", "application/json"));
 
     // Then
-    assertThrowsExactly(PidResolutionException.class, () -> pidResolver.getObjectName(EXTERNAL_PID
-    ));
+    assertThrowsExactly(PidResolutionException.class, () -> pidResolver.getObjectName(EXTERNAL_PID,
+        true));
   }
 
   @Test
-  void testRetriesSuccess() throws Exception {
+  void testRetriesSuccessHandle() throws Exception {
     // Given
     int requestCount = mockServer.getRequestCount();
     var expectedResponse = MAPPER.readTree(loadResourceFile("pidrecord/pidRecord.json"));
@@ -179,7 +271,7 @@ class PidResolverTest {
         .addHeader("Content-Type", "application/json"));
 
     // When
-    var response = pidResolver.getObjectName(EXTERNAL_PID);
+    var response = pidResolver.getObjectName(EXTERNAL_PID, false);
 
     // Then
     assertThat(response).isEqualTo(expected);
@@ -197,13 +289,13 @@ class PidResolverTest {
 
     // Then
     assertThrowsExactly(PidResolutionException.class,
-        () -> pidResolver.getObjectName(EXTERNAL_PID));
+        () -> pidResolver.getObjectName(EXTERNAL_PID, true));
     assertThat(mockServer.getRequestCount() - requestCount).isEqualTo(4);
   }
 
 
   @Test
-  void testRedirect() throws Exception {
+  void testRedirectHandle() throws Exception {
     // Given
     var expectedResponse = MAPPER.readTree(loadResourceFile("pidrecord/pidRecord.json"));
     var expected = expectedResponse.get("name").asText();
@@ -218,7 +310,7 @@ class PidResolverTest {
         .addHeader("Content-Type", "application/json"));
 
     // When
-    var response = pidResolver.getObjectName(EXTERNAL_PID);
+    var response = pidResolver.getObjectName(EXTERNAL_PID, false);
 
     // Then
     assertThat(response).isEqualTo(expected);

--- a/src/test/java/eu/dissco/core/handlemanager/component/PidResolverTest.java
+++ b/src/test/java/eu/dissco/core/handlemanager/component/PidResolverTest.java
@@ -102,7 +102,7 @@ class PidResolverTest {
   }
 
   @Test
-  void testResolveRorNoEnglish() throws Exception {
+  void testResolveRorNoRorDisplay() throws Exception {
     var expected = "Nederlands Centrum voor Biodiversiteit Naturalis";
     var response = MAPPER.readTree("""
         {
@@ -135,8 +135,8 @@ class PidResolverTest {
         {
          "names": [
             {
-              "language": "nl",
-              "types": [
+              "lang": "nl",
+              "type": [
                 "label"
               ],
               "value": "Nederlands Centrum voor Biodiversiteit Naturalis"

--- a/src/test/java/eu/dissco/core/handlemanager/service/FdoRecordServiceTest.java
+++ b/src/test/java/eu/dissco/core/handlemanager/service/FdoRecordServiceTest.java
@@ -64,6 +64,7 @@ import static eu.dissco.core.handlemanager.testUtils.TestUtils.givenUpdatedFdoRe
 import static eu.dissco.core.handlemanager.testUtils.TestUtils.setLocations;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
@@ -110,7 +111,7 @@ class FdoRecordServiceTest {
   void init() throws PidResolutionException {
     fdoRecordService = new FdoRecordService(TRANSFORMER_FACTORY, DOC_BUILDER_FACTORY, pidResolver,
         MAPPER, applicationProperties, profileProperties);
-    given(pidResolver.getObjectName(any())).willReturn(SPECIMEN_HOST_NAME_TESTVAL);
+    given(pidResolver.getObjectName(any(), anyBoolean())).willReturn(SPECIMEN_HOST_NAME_TESTVAL);
     given(applicationProperties.getPrefix()).willReturn(PREFIX);
     given(applicationProperties.getApiUrl()).willReturn(API_URL);
     given(applicationProperties.getOrchestrationUrl()).willReturn(ORCHESTRATION_URL);
@@ -147,7 +148,9 @@ class FdoRecordServiceTest {
     fdoRecordService.prepareNewOrganisationRecord(request, HANDLE, CREATED, false);
 
     // Then
-    then(pidResolver).should().getObjectName("https://api.ror.org/organizations/" + ROR_IDENTIFIER);
+    then(pidResolver).should()
+        .getObjectName("https://api.ror.org/v2/organizations/" + ROR_IDENTIFIER,
+            true);
   }
 
   @Test
@@ -160,7 +163,7 @@ class FdoRecordServiceTest {
     fdoRecordService.prepareNewOrganisationRecord(request, HANDLE, CREATED, false);
 
     // Then
-    then(pidResolver).should().getObjectName(id);
+    then(pidResolver).should().getObjectName(id, false);
   }
 
   @Test


### PR DESCRIPTION
Uses ror v2 api. Extracts `ror_label`
Name is now an object, have a bit of logic to extract:
See https://api.ror.org/v2/organizations/https://ror.org/0566bfb96 
```
 "names": [
    {
      "lang": "en",
      "types": [
        "ror_display",
        "label"
      ],
      "value": "Naturalis Biodiversity Center"
    },
    {
      "lang": "nl",
      "types": [
        "label"
      ],
      "value": "Nederlands Centrum voor Biodiversiteit Naturalis"
    }
  ]

```