### PR TITLE
Feature/fdo update

### DIFF
--- a/src/main/java/eu/dissco/core/handlemanager/domain/datacite/EventType.java
+++ b/src/main/java/eu/dissco/core/handlemanager/domain/datacite/EventType.java
@@ -1,7 +1,6 @@
 package eu.dissco.core.handlemanager.domain.datacite;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import eu.dissco.core.handlemanager.Profiles;
 import org.springframework.context.annotation.Profile;
 
@@ -9,5 +8,5 @@ import org.springframework.context.annotation.Profile;
 public enum EventType {
 
   @JsonProperty("create") CREATE,
-  @JsonPropertyOrder("update") UPDATE;
+  @JsonProperty("update") UPDATE;
 }

--- a/src/main/java/eu/dissco/core/handlemanager/domain/fdo/FdoProfile.java
+++ b/src/main/java/eu/dissco/core/handlemanager/domain/fdo/FdoProfile.java
@@ -41,7 +41,7 @@ public enum FdoProfile {
   LIVING_OR_PRESERVED("livingOrPreserved", 208),
   MATERIAL_SAMPLE_TYPE("materialSampleType", 209),
   MARKED_AS_TYPE("markedAsType", 210),
-  CATALOG_IDENTIFIER("catalogIdentifier", 211),
+  CATALOG_NUMBER("catalogNumber", 211),
 
   // Media
   MEDIA_HOST("mediaHost", 400),
@@ -54,9 +54,9 @@ public enum FdoProfile {
   MEDIA_TYPE("mediaType", 408),
   MIME_TYPE("mimeType", 409),
   LICENSE_NAME("licenseName", 410),
-  LICENSE_ID("licenseId", 411),
-  RIGHTS_HOLDER_NAME("rightsHolderName", 412),
-  RIGHTS_HOLDER_PID("rightsHolderId", 413),
+  LICENSE_URL("licenseUrl", 411),
+  RIGHTS_HOLDER_NAME("rightsHolder", 412),
+  RIGHTS_HOLDER_PID("rightsHolderPid", 413),
 
   // Annotation
   TARGET_PID("targetPid", 500),
@@ -76,7 +76,9 @@ public enum FdoProfile {
 
   // Administration
   HS_ADMIN("HS_ADMIN", 100),
-  LOC("10320/loc", 101);
+  LOC("10320/loc", 101),
+  UNRECOGNIZED("Unrecognized", 900);
+
 
   private static final Map<String, FdoProfile> LOOKUP;
 
@@ -88,7 +90,7 @@ public enum FdoProfile {
   }
 
   public static FdoProfile fromString(String attributeName) {
-    return LOOKUP.get(attributeName);
+    return LOOKUP.getOrDefault(attributeName, UNRECOGNIZED);
   }
 
   private final String attribute;

--- a/src/main/java/eu/dissco/core/handlemanager/repository/MongoRepository.java
+++ b/src/main/java/eu/dissco/core/handlemanager/repository/MongoRepository.java
@@ -111,11 +111,12 @@ public class MongoRepository {
 
   private static Map<FdoProfile, FdoAttribute> buildAttributeMap(
       Collection<FdoAttribute> attributeList) {
-    return attributeList.stream().collect(Collectors.toMap(
-        a -> FdoProfile.fromString(a.getType()),
-        Function.identity(),
-        (oldVal, newVal) -> oldVal
-    ));
+    return attributeList.stream()
+        .collect(Collectors.toMap(
+            a -> FdoProfile.fromString(a.getType()),
+            Function.identity(),
+            (oldVal, newVal) -> oldVal
+        ));
   }
 
   private String getLocalId(JsonNode jsonRecord, FdoType fdoType) {

--- a/src/main/java/eu/dissco/core/handlemanager/service/FdoRecordService.java
+++ b/src/main/java/eu/dissco/core/handlemanager/service/FdoRecordService.java
@@ -3,7 +3,7 @@ package eu.dissco.core.handlemanager.service;
 
 import static eu.dissco.core.handlemanager.configuration.AppConfig.DATE_STRING;
 import static eu.dissco.core.handlemanager.domain.fdo.FdoProfile.ANNOTATION_HASH;
-import static eu.dissco.core.handlemanager.domain.fdo.FdoProfile.CATALOG_IDENTIFIER;
+import static eu.dissco.core.handlemanager.domain.fdo.FdoProfile.CATALOG_NUMBER;
 import static eu.dissco.core.handlemanager.domain.fdo.FdoProfile.DIGITAL_OBJECT_NAME;
 import static eu.dissco.core.handlemanager.domain.fdo.FdoProfile.DIGITAL_OBJECT_TYPE;
 import static eu.dissco.core.handlemanager.domain.fdo.FdoProfile.FDO_PROFILE;
@@ -13,8 +13,8 @@ import static eu.dissco.core.handlemanager.domain.fdo.FdoProfile.HAS_RELATED_PID
 import static eu.dissco.core.handlemanager.domain.fdo.FdoProfile.HS_ADMIN;
 import static eu.dissco.core.handlemanager.domain.fdo.FdoProfile.ISSUED_FOR_AGENT;
 import static eu.dissco.core.handlemanager.domain.fdo.FdoProfile.ISSUED_FOR_AGENT_NAME;
-import static eu.dissco.core.handlemanager.domain.fdo.FdoProfile.LICENSE_ID;
 import static eu.dissco.core.handlemanager.domain.fdo.FdoProfile.LICENSE_NAME;
+import static eu.dissco.core.handlemanager.domain.fdo.FdoProfile.LICENSE_URL;
 import static eu.dissco.core.handlemanager.domain.fdo.FdoProfile.LINKED_DO_PID;
 import static eu.dissco.core.handlemanager.domain.fdo.FdoProfile.LINKED_DO_TYPE;
 import static eu.dissco.core.handlemanager.domain.fdo.FdoProfile.LIVING_OR_PRESERVED;
@@ -366,7 +366,7 @@ public class FdoRecordService {
       throws InvalidRequestException, JsonProcessingException {
     var handleAttributeList = new EnumMap<FdoProfile, FdoAttribute>(FdoProfile.class);
     // 101: 10320/Loc
-    var keyAttribute = getSpecimenResolvableId(request.getCatalogIdentifier(),
+    var keyAttribute = getSpecimenResolvableId(request.getCatalogNumber(),
         request.getOtherSpecimenIds());
     handleAttributeList.put(LOC,
         new FdoAttribute(LOC, timestamp,
@@ -416,8 +416,8 @@ public class FdoRecordService {
     handleAttributeList.put(MARKED_AS_TYPE,
         new FdoAttribute(MARKED_AS_TYPE, timestamp, request.getMarkedAsType()));
     // 211 Catalog Number
-    handleAttributeList.put(CATALOG_IDENTIFIER,
-        new FdoAttribute(CATALOG_IDENTIFIER, timestamp, request.getCatalogIdentifier()));
+    handleAttributeList.put(CATALOG_NUMBER,
+        new FdoAttribute(CATALOG_NUMBER, timestamp, request.getCatalogNumber()));
     return handleAttributeList;
   }
 
@@ -552,15 +552,16 @@ public class FdoRecordService {
     handleAttributeList.put(LICENSE_NAME,
         new FdoAttribute(LICENSE_NAME, timestamp, request.getLicenseName()));
     // 410 License Id
-    handleAttributeList.put(LICENSE_ID,
-        new FdoAttribute(LICENSE_ID, timestamp, request.getLicenseId()));
-    // 411 Rights Holder Id
+    handleAttributeList.put(LICENSE_URL,
+        new FdoAttribute(LICENSE_URL, timestamp, request.getLicenseUrl()));
+    // 411 Rights Holder Pid
     var rightsHolder =
-        request.getRightsHolderId() == null ? request.getMediaHost() : request.getRightsHolderId();
+        request.getRightsHolderPid() == null ? request.getMediaHost()
+            : request.getRightsHolderPid();
     handleAttributeList.put(RIGHTS_HOLDER_PID,
         new FdoAttribute(RIGHTS_HOLDER_PID, timestamp, rightsHolder));
-    String rightsHolderName = request.getRightsHolderName() != null ?
-        getObjectName(request.getRightsHolderId(), request.getRightsHolderName()) : mediaHostName;
+    String rightsHolderName = request.getRightsHolder() != null ?
+        getObjectName(request.getRightsHolderPid(), request.getRightsHolder()) : mediaHostName;
     // 412 Rights Holder Name
     handleAttributeList.put(RIGHTS_HOLDER_NAME,
         new FdoAttribute(RIGHTS_HOLDER_NAME, timestamp, rightsHolderName));
@@ -812,7 +813,7 @@ public class FdoRecordService {
     try {
       switch (fdoType) {
         case DIGITAL_SPECIMEN -> {
-          var catalogIdValue = fdoAttributes.get(CATALOG_IDENTIFIER);
+          var catalogIdValue = fdoAttributes.get(CATALOG_NUMBER);
           var catalogId = catalogIdValue == null ? null : catalogIdValue.getValue();
           var otherSpecimenIdsField = fdoAttributes.get(OTHER_SPECIMEN_IDS);
           var otherSpecimenIds =

--- a/src/main/resources/json-schema/digital-media-request-attributes.json
+++ b/src/main/resources/json-schema/digital-media-request-attributes.json
@@ -61,35 +61,44 @@
       "type": "string",
       "description": "Only mimetypes for audio, image, model, video, text should be provided. https://www.iana.org/assignments/media-types/media-types.xhtml"
     },
+    "license": {
+      "type": "string",
+      "description": "Maps to dcterms:license, unenforced value that may or may not be machine actionable. http://purl.org/dc/terms/license.",
+      "example": "CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
+      "$comment": "idx = 409"
+    },
     "licenseName": {
       "type": "string",
       "description": "Human-readable name of the license",
       "example": "CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
       "$comment": "idx = 409"
     },
-    "licenseId": {
+    "licenseUrl": {
       "type": "string",
       "description": "Machine-actionable licensing information. Uses SPDX Identifiers.",
       "example": "https://spdx.org/licenses/CC0-1.0",
       "$comment": "idx = 410"
     },
-    "rightsHolderName": {
+    "rightsHolder": {
       "type": "string",
       "description": "If not present, defaults to mediaHost, https://purl.org/dc/terms/rightsHolder",
       "example": "https://ror.org/0566bfb96"
     },
-    "rightsHolderId": {
+    "rightsHolderPid": {
       "type": "string",
       "description": "Resolvable identifier of the rights holder",
       "example": "https://ror.org/0566bfb96"
     }
   },
   "required": [
+    "referentName",
     "mediaHost",
     "mediaHostName",
     "linkedDigitalObjectPid",
     "linkedDigitalObjectType",
-    "primaryMediaId"
+    "primaryMediaId",
+    "license",
+    "rightsHolder"
   ],
   "additionalProperties": false
 }

--- a/src/main/resources/json-schema/digital-specimen-request-attributes.json
+++ b/src/main/resources/json-schema/digital-specimen-request-attributes.json
@@ -2,7 +2,7 @@
   "$id": "https://schemas.dissco.tech/schemas/fdo-profile/digital-specimen/0.1.0/digital-specimen-request-attributes.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "Attributes of a request to the DiSSCo PID API to create a FDO Record for a digital specimen",
-  "$comment": "FDO Profile Version 1.0.0",
+  "$comment": "FDO Profile Version 0.1.0",
   "properties": {
     "locations": {
       "type": "array",
@@ -94,7 +94,7 @@
       "enum": [
         "Human remains",
         "Hominid remains",
-        "Macrofungi, Lichens & Myxomycetes",
+        "Mycology",
         "Algae",
         "Bryophytes",
         "Pteridophytes",
@@ -128,18 +128,13 @@
         "Other Palaeontology Objects",
         "Minerals and Gems",
         "Loose Sediment Sample",
-        "Mixed Solid Matter Sample",
+        "Mixed Solid Mater Sample",
         "Water-Ice Sample",
         "Liquid or Gaseous Matter Sample",
         "Mixed Geology Objects",
         "Terrestrial Finds/Falls",
         "Terrestrial Impacta",
         "Sample Returns",
-        "Sedimentary Rock",
-        "Metamorphic or Igneous Rock",
-        "Plant Genetic Resource",
-        "Floral and Faunal remains",
-        "Other Anthropology Objects",
         "Unclassified"
       ],
       "description": "Countable things (objects) served as a more detailed classification of each of the disciplines."
@@ -153,20 +148,12 @@
     },
     "materialSampleType": {
       "enum": [
-        "Whole organism specimen",
-        "Organism part",
-        "Organism product",
-        "Biome aggregation",
-        "Bundle biome aggregation",
-        "Fossil",
         "Any biological specimen",
-        "Aggregation",
-        "Slurry biome aggregation",
-        "Other solid object",
+        "Biological material sample",
         "Fluid in container",
-        "Anthropogenic aggregation",
-        "Artefact",
-        "Any aggregation specimen"
+        "Fluid in container",
+        "Non biologic solid object",
+        "Research product"
       ],
       "description": "https://isamplesorg.github.io/models/generated/vocabularies/specimenType.html"
     },
@@ -174,9 +161,9 @@
       "type": "boolean",
       "description": "TRUE if the specimen is marked as type with a stamp or label."
     },
-    "catalogIdentifier": {
+    "catalogNumber": {
       "type": "string",
-      "description": "Identifier of source system catalog"
+      "description": "Number of the specimen in the source system catalog"
     }
   },
   "required": [

--- a/src/test/java/eu/dissco/core/handlemanager/service/FdoRecordServiceTest.java
+++ b/src/test/java/eu/dissco/core/handlemanager/service/FdoRecordServiceTest.java
@@ -1,6 +1,6 @@
 package eu.dissco.core.handlemanager.service;
 
-import static eu.dissco.core.handlemanager.domain.fdo.FdoProfile.CATALOG_IDENTIFIER;
+import static eu.dissco.core.handlemanager.domain.fdo.FdoProfile.CATALOG_NUMBER;
 import static eu.dissco.core.handlemanager.domain.fdo.FdoProfile.LOC;
 import static eu.dissco.core.handlemanager.domain.fdo.FdoProfile.OTHER_SPECIMEN_IDS;
 import static eu.dissco.core.handlemanager.domain.fdo.FdoProfile.PID_RECORD_ISSUE_NUMBER;
@@ -347,10 +347,10 @@ class FdoRecordServiceTest {
   @Test
   void testPrepareNewDigitalSpecimenRecordNoOtherSpecimen() throws Exception {
     // Given
-    var request = givenDigitalSpecimen().withCatalogIdentifier(null);
+    var request = givenDigitalSpecimen().withCatalogNumber(null);
     var expectedAttributes = new EnumMap<>(givenDigitalSpecimenFdoRecord(HANDLE).attributes());
-    expectedAttributes.replace(CATALOG_IDENTIFIER,
-        new FdoAttribute(CATALOG_IDENTIFIER, CREATED, null));
+    expectedAttributes.replace(CATALOG_NUMBER,
+        new FdoAttribute(CATALOG_NUMBER, CREATED, null));
     expectedAttributes.replace(LOC,
         new FdoAttribute(LOC, CREATED, setLocations(HANDLE, FdoType.DIGITAL_SPECIMEN, false)));
 
@@ -373,7 +373,7 @@ class FdoRecordServiceTest {
   void testGetSpecimenResolvableIdOtherId(String catalogId) throws Exception {
     // Given
     var keyLoc = CATALOG_ID_TEST + "A";
-    var request = givenDigitalSpecimen().withCatalogIdentifier(catalogId).withOtherSpecimenIds(
+    var request = givenDigitalSpecimen().withCatalogNumber(catalogId).withOtherSpecimenIds(
         List.of(new OtherspecimenIds().withIdentifierType("Local id").withIdentifierValue("ABC")
                 .withResolvable(false),
             new OtherspecimenIds().withIdentifierType("Resolvable id").withIdentifierValue(keyLoc)

--- a/src/test/java/eu/dissco/core/handlemanager/testUtils/TestUtils.java
+++ b/src/test/java/eu/dissco/core/handlemanager/testUtils/TestUtils.java
@@ -1,7 +1,7 @@
 package eu.dissco.core.handlemanager.testUtils;
 
 import static eu.dissco.core.handlemanager.domain.fdo.FdoProfile.ANNOTATION_HASH;
-import static eu.dissco.core.handlemanager.domain.fdo.FdoProfile.CATALOG_IDENTIFIER;
+import static eu.dissco.core.handlemanager.domain.fdo.FdoProfile.CATALOG_NUMBER;
 import static eu.dissco.core.handlemanager.domain.fdo.FdoProfile.DIGITAL_OBJECT_NAME;
 import static eu.dissco.core.handlemanager.domain.fdo.FdoProfile.DIGITAL_OBJECT_TYPE;
 import static eu.dissco.core.handlemanager.domain.fdo.FdoProfile.FDO_PROFILE;
@@ -11,8 +11,8 @@ import static eu.dissco.core.handlemanager.domain.fdo.FdoProfile.HAS_RELATED_PID
 import static eu.dissco.core.handlemanager.domain.fdo.FdoProfile.HS_ADMIN;
 import static eu.dissco.core.handlemanager.domain.fdo.FdoProfile.ISSUED_FOR_AGENT;
 import static eu.dissco.core.handlemanager.domain.fdo.FdoProfile.ISSUED_FOR_AGENT_NAME;
-import static eu.dissco.core.handlemanager.domain.fdo.FdoProfile.LICENSE_ID;
 import static eu.dissco.core.handlemanager.domain.fdo.FdoProfile.LICENSE_NAME;
+import static eu.dissco.core.handlemanager.domain.fdo.FdoProfile.LICENSE_URL;
 import static eu.dissco.core.handlemanager.domain.fdo.FdoProfile.LINKED_DO_PID;
 import static eu.dissco.core.handlemanager.domain.fdo.FdoProfile.LINKED_DO_TYPE;
 import static eu.dissco.core.handlemanager.domain.fdo.FdoProfile.LIVING_OR_PRESERVED;
@@ -382,8 +382,8 @@ public class TestUtils {
     fdoRecord.put(MATERIAL_SAMPLE_TYPE, new FdoAttribute(MATERIAL_SAMPLE_TYPE, timestamp, null));
     fdoRecord.put(MARKED_AS_TYPE,
         new FdoAttribute(MARKED_AS_TYPE, timestamp, null));
-    fdoRecord.put(CATALOG_IDENTIFIER,
-        new FdoAttribute(CATALOG_IDENTIFIER, timestamp, CATALOG_ID_TEST));
+    fdoRecord.put(CATALOG_NUMBER,
+        new FdoAttribute(CATALOG_NUMBER, timestamp, CATALOG_ID_TEST));
     return fdoRecord;
   }
 
@@ -426,7 +426,7 @@ public class TestUtils {
     fdoRecord.put(MEDIA_TYPE, new FdoAttribute(MEDIA_TYPE, timestamp, null));
     fdoRecord.put(MIME_TYPE, new FdoAttribute(MIME_TYPE, timestamp, null));
     fdoRecord.put(LICENSE_NAME, new FdoAttribute(LICENSE_NAME, timestamp, null));
-    fdoRecord.put(LICENSE_ID, new FdoAttribute(LICENSE_ID, timestamp, null));
+    fdoRecord.put(LICENSE_URL, new FdoAttribute(LICENSE_URL, timestamp, null));
     fdoRecord.put(RIGHTS_HOLDER_NAME,
         new FdoAttribute(RIGHTS_HOLDER_NAME, timestamp, SPECIMEN_HOST_NAME_TESTVAL));
     fdoRecord.put(RIGHTS_HOLDER_PID,
@@ -605,7 +605,7 @@ public class TestUtils {
 
   public static DigitalSpecimenRequestAttributes givenDigitalSpecimen() {
     return new DigitalSpecimenRequestAttributes()
-        .withCatalogIdentifier(CATALOG_ID_TEST)
+        .withCatalogNumber(CATALOG_ID_TEST)
         .withReferentName(REFERENT_NAME_TESTVAL)
         .withSpecimenHost(SPECIMEN_HOST_TESTVAL)
         .withSpecimenHostName(SPECIMEN_HOST_NAME_TESTVAL)
@@ -624,9 +624,10 @@ public class TestUtils {
         .withMediaHostName(MEDIA_HOST_NAME_TESTVAL)
         .withLinkedDigitalObjectPid(LINKED_DO_PID_TESTVAL)
         .withLinkedDigitalObjectType(DIGITAL_SPECIMEN.getDigitalObjectType())
-        .withRightsHolderId(SPECIMEN_HOST_TESTVAL)
+        .withRightsHolderPid(SPECIMEN_HOST_TESTVAL)
         .withPrimaryMediaId(PRIMARY_MEDIA_ID_TESTVAL)
-        .withRightsHolderName(SPECIMEN_HOST_NAME_TESTVAL);
+        .withRightsHolder(SPECIMEN_HOST_NAME_TESTVAL)
+        .withLicense("https://spdx.org/licenses/CC0-1.0.json");
   }
 
   public static DigitalMediaRequestAttributes givenDigitalMediaUpdated() {


### PR DESCRIPTION
- align with fdo 1.0
- introduces "unrecognized" fdo property as a small workaround in the mongodb layer so the handle api won't crash if a pid record has a property from a previous version