### PR TITLE
add upsert for pids

### DIFF
--- a/.github/workflows/.trivyignore
+++ b/.github/workflows/.trivyignore
@@ -1,8 +1,5 @@
-# Sep 5
-# Issue with netty - wait for spring boot update
-CVE-2025-58056
-CVE-2025-55163
-
-# Sep 10
-# Issue with tomcat - wait for spring boot update
-CVE-2025-48989
+# Dec 8
+# Issue with tomcat/spring - will likely need to update to spring boot 4.0
+CVE-2025-55752
+CVE-2025-41248
+CVE-2025-41249

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>spring-boot-starter-parent</artifactId>
     <groupId>org.springframework.boot</groupId>
     <relativePath/>
-    <version>3.5.3</version> <!-- lookup parent from repository -->
+    <version>3.5.8</version> <!-- lookup parent from repository -->
   </parent>
   <artifactId>handle-manager</artifactId>
   <version>0.0.1-SNAPSHOT</version>

--- a/src/main/java/eu/dissco/core/handlemanager/repository/MongoRepository.java
+++ b/src/main/java/eu/dissco/core/handlemanager/repository/MongoRepository.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.model.ReplaceOneModel;
+import com.mongodb.client.model.ReplaceOptions;
 import eu.dissco.core.handlemanager.domain.fdo.FdoProfile;
 import eu.dissco.core.handlemanager.domain.fdo.FdoType;
 import eu.dissco.core.handlemanager.domain.repsitoryobjects.FdoAttribute;
@@ -62,10 +63,11 @@ public class MongoRepository {
     }
   }
 
-  public void updateHandleRecords(List<Document> handleRecords) {
+  public void updateHandleRecords(List<Document> handleRecords, boolean upsert) {
+    var options = new ReplaceOptions().upsert(upsert);
     var queryList = handleRecords.stream().map(doc -> {
       var filter = eq(doc.get(ID));
-      return new ReplaceOneModel<>(filter, doc);
+      return new ReplaceOneModel<>(filter, doc, options);
     }).toList();
     log.info("Updating {} records to database", handleRecords.size());
     if (!queryList.isEmpty()) {

--- a/src/main/java/eu/dissco/core/handlemanager/service/PidService.java
+++ b/src/main/java/eu/dissco/core/handlemanager/service/PidService.java
@@ -268,7 +268,7 @@ public abstract class PidService {
       log.error("JsonProcessingException while tombstoning records", e);
       throw new InvalidRequestException(REQUEST_PROCESSING_ERR);
     }
-    mongoRepository.updateHandleRecords(fdoDocuments);
+    mongoRepository.updateHandleRecords(fdoDocuments, false);
     return new JsonApiWrapperWrite(formatFdoRecord(fdoRecords, TOMBSTONE));
   }
 
@@ -388,11 +388,11 @@ public abstract class PidService {
       throw new InvalidRequestException(REQUEST_PROCESSING_ERR);
     }
     if (applicationProperties.isUseManualPids()) {
-      mongoRepository.updateHandleRecords(fdoDocuments);
+      mongoRepository.updateHandleRecords(fdoDocuments, true);
+      deleteManualPids(fdoRecords);
     } else {
       mongoRepository.postHandleRecords(fdoDocuments);
     }
-    deleteManualPids(fdoRecords);
     log.info("Successfully posted {} fdo records to database", fdoDocuments.size());
   }
 
@@ -409,7 +409,7 @@ public abstract class PidService {
       throw new InvalidRequestException(
           REQUEST_PROCESSING_ERR);
     }
-    mongoRepository.updateHandleRecords(fdoDocuments);
+    mongoRepository.updateHandleRecords(fdoDocuments, false);
     log.info("Successfully updated {} specimens fdo records to database", fdoDocuments.size());
   }
 

--- a/src/test/java/eu/dissco/core/handlemanager/repository/MongoRepositoryIT.java
+++ b/src/test/java/eu/dissco/core/handlemanager/repository/MongoRepositoryIT.java
@@ -239,6 +239,36 @@ class MongoRepositoryIT {
   }
 
   @Test
+  void testUpdateHandleRecordsUpsertNotPresent() throws Exception {
+    // Given
+    var expected = givenMongoDocument(givenUpdatedFdoRecord(FdoType.DIGITAL_SPECIMEN,
+        NORMALISED_PRIMARY_SPECIMEN_OBJECT_ID_TESTVAL));
+
+    // When
+    repository.updateHandleRecords(List.of(expected), true);
+    var result = collection.find(eq("_id", HANDLE)).first();
+
+    // Then
+    assertThat(result).isEqualTo(expected);
+  }
+
+  @Test
+  void testUpdateHandleRecordsUpsertPresentAndUpdated() throws Exception {
+    // Given
+    var specimenDoc = givenMongoDocument(givenDigitalSpecimenFdoRecord(HANDLE));
+    collection.insertOne(specimenDoc);
+    var expected = givenMongoDocument(givenUpdatedFdoRecord(FdoType.DIGITAL_SPECIMEN,
+        NORMALISED_PRIMARY_SPECIMEN_OBJECT_ID_TESTVAL));
+
+    // When
+    repository.updateHandleRecords(List.of(expected), true);
+    var result = collection.find(eq("_id", HANDLE)).first();
+
+    // Then
+    assertThat(result).isEqualTo(expected);
+  }
+
+  @Test
   void testSearchByPrimaryLocalIdSpecimen() throws Exception {
     // Given
     populateMongoDB();

--- a/src/test/java/eu/dissco/core/handlemanager/repository/MongoRepositoryIT.java
+++ b/src/test/java/eu/dissco/core/handlemanager/repository/MongoRepositoryIT.java
@@ -75,7 +75,7 @@ class MongoRepositoryIT {
   @Test
   void testUpdateEmptyList() {
     // When / Then
-    assertDoesNotThrow(() -> repository.updateHandleRecords(List.of()));
+    assertDoesNotThrow(() -> repository.updateHandleRecords(List.of(), false));
   }
 
   @Test
@@ -231,7 +231,7 @@ class MongoRepositoryIT {
         NORMALISED_PRIMARY_SPECIMEN_OBJECT_ID_TESTVAL));
 
     // When
-    repository.updateHandleRecords(List.of(expected));
+    repository.updateHandleRecords(List.of(expected), false);
     var result = collection.find(eq("_id", HANDLE)).first();
 
     // Then

--- a/src/test/java/eu/dissco/core/handlemanager/service/DoiServiceTest.java
+++ b/src/test/java/eu/dissco/core/handlemanager/service/DoiServiceTest.java
@@ -170,7 +170,35 @@ class DoiServiceTest {
 
     // Then
     assertThat(responseReceived).isEqualTo(responseExpected);
-    then(mongoRepository).should().updateHandleRecords(any());
+    then(mongoRepository).should().updateHandleRecords(any(), eq(true));
+    then(mongoRepository).should().searchByPrimaryLocalId(any(), any());
+    then(mongoRepository).shouldHaveNoMoreInteractions();
+    then(dataCiteService).should().publishToDataCite(dataCiteEvent, FdoType.DIGITAL_SPECIMEN);
+  }
+
+  @Test
+  void testOverwriteCreateDigitalSpecimenPidsDepleted() throws Exception {
+    // Given
+    var request = givenPostRequest(givenDigitalSpecimen(), FdoType.DIGITAL_SPECIMEN);
+    var fdoRecord = givenDigitalSpecimenFdoRecord(HANDLE);
+    var responseExpected = givenWriteResponseIdsOnly(List.of(fdoRecord), FdoType.DIGITAL_SPECIMEN,
+        DOI_DOMAIN);
+    var dataCiteEvent = new DataCiteEvent(jsonFormatFdoRecord(fdoRecord.values()),
+        EventType.CREATE);
+    given(mongoRepository.getHandleRecords(List.of(HANDLE))).willReturn(List.of());
+    given(pidNameGeneratorService.generateNewHandles(1)).willReturn(Set.of(HANDLE));
+    given(fdoRecordService.prepareNewDigitalSpecimenRecord(any(), any(), any(),
+        anyBoolean())).willReturn(
+        fdoRecord);
+    given(profileProperties.getDomain()).willReturn(DOI_DOMAIN);
+    given(applicationProperties.isUseManualPids()).willReturn(true);
+
+    // When
+    var responseReceived = service.createRecords(List.of(request), false);
+
+    // Then
+    assertThat(responseReceived).isEqualTo(responseExpected);
+    then(mongoRepository).should().updateHandleRecords(any(), eq(true));
     then(mongoRepository).should().searchByPrimaryLocalId(any(), any());
     then(mongoRepository).shouldHaveNoMoreInteractions();
     then(dataCiteService).should().publishToDataCite(dataCiteEvent, FdoType.DIGITAL_SPECIMEN);
@@ -362,7 +390,7 @@ class DoiServiceTest {
 
     // Then
     assertThat(responseReceived).isEqualTo(responseExpected);
-    then(mongoRepository).should().updateHandleRecords(List.of(expectedDocument));
+    then(mongoRepository).should().updateHandleRecords(List.of(expectedDocument), false);
     then(dataCiteService).should().publishToDataCite(expectedEvent, FdoType.DIGITAL_SPECIMEN);
   }
 
@@ -389,7 +417,7 @@ class DoiServiceTest {
 
     // Then
     assertThat(responseReceived).isEqualTo(responseExpected);
-    then(mongoRepository).should().updateHandleRecords(List.of(expectedDocument));
+    then(mongoRepository).should().updateHandleRecords(List.of(expectedDocument), false);
     then(dataCiteService).should().publishToDataCite(expectedEvent, FdoType.DIGITAL_MEDIA);
   }
 
@@ -513,7 +541,7 @@ class DoiServiceTest {
         () -> service.updateRecords(updateRequest, true));
 
     // Then
-    then(mongoRepository).should().updateHandleRecords(List.of(expectedDocument));
+    then(mongoRepository).should().updateHandleRecords(List.of(expectedDocument), false);
     then(mongoRepository).shouldHaveNoMoreInteractions();
   }
 
@@ -544,7 +572,7 @@ class DoiServiceTest {
 
     // Then
     assertThat(result).isEqualTo(expected);
-    then(mongoRepository).should().updateHandleRecords(List.of(expectedDocument));
+    then(mongoRepository).should().updateHandleRecords(List.of(expectedDocument), false);
     then(dataCiteService).should().tombstoneDataCite(HANDLE, List.of(givenHasRelatedPid()));
   }
 
@@ -567,7 +595,7 @@ class DoiServiceTest {
 
     // Then
     assertThat(result).isEqualTo(expected);
-    then(mongoRepository).should().updateHandleRecords(List.of(expectedDocument));
+    then(mongoRepository).should().updateHandleRecords(List.of(expectedDocument), false);
     then(dataCiteService).should().tombstoneDataCite(HANDLE, List.of(givenHasRelatedPid()));
   }
 
@@ -607,7 +635,7 @@ class DoiServiceTest {
 
     // Then
     assertThat(result).isEqualTo(expected);
-    then(mongoRepository).should().updateHandleRecords(List.of(expectedDocument));
+    then(mongoRepository).should().updateHandleRecords(List.of(expectedDocument), false);
   }
 
 }

--- a/src/test/java/eu/dissco/core/handlemanager/service/HandleServiceTest.java
+++ b/src/test/java/eu/dissco/core/handlemanager/service/HandleServiceTest.java
@@ -189,7 +189,7 @@ class HandleServiceTest {
 
     // Then
     assertThat(result).isEqualTo(expected);
-    then(mongoRepository).should().updateHandleRecords(List.of(expectedDocument));
+    then(mongoRepository).should().updateHandleRecords(List.of(expectedDocument), false);
   }
 
   @Test
@@ -250,7 +250,7 @@ class HandleServiceTest {
     service.activateRecords(List.of(HANDLE));
 
     // Then
-    then(mongoRepository).should().updateHandleRecords(List.of(expected));
+    then(mongoRepository).should().updateHandleRecords(List.of(expected), false);
   }
 
   @Test
@@ -272,7 +272,7 @@ class HandleServiceTest {
 
     // Then
     assertThat(result).isEqualTo(expected);
-    then(mongoRepository).should().updateHandleRecords(List.of(expectedDocument));
+    then(mongoRepository).should().updateHandleRecords(List.of(expectedDocument), false);
   }
 
   @Test
@@ -334,7 +334,7 @@ class HandleServiceTest {
 
     // Then
     assertThat(result).isEqualTo(expected);
-    then(mongoRepository).should().updateHandleRecords(List.of(expectedDocument));
+    then(mongoRepository).should().updateHandleRecords(List.of(expectedDocument), false);
   }
 
   @Test
@@ -373,7 +373,7 @@ class HandleServiceTest {
 
     // Then
     assertThat(result).isEqualTo(expected);
-    then(mongoRepository).should().updateHandleRecords(List.of(expectedDocument));
+    then(mongoRepository).should().updateHandleRecords(List.of(expectedDocument), false);
   }
 
   @Test
@@ -413,7 +413,7 @@ class HandleServiceTest {
 
     // Then
     assertThat(result).isEqualTo(expected);
-    then(mongoRepository).should().updateHandleRecords(List.of(expectedDocument));
+    then(mongoRepository).should().updateHandleRecords(List.of(expectedDocument), false);
   }
 
   @Test
@@ -452,7 +452,7 @@ class HandleServiceTest {
 
     // Then
     assertThat(result).isEqualTo(expected);
-    then(mongoRepository).should().updateHandleRecords(List.of(expectedDocument));
+    then(mongoRepository).should().updateHandleRecords(List.of(expectedDocument), false);
   }
 
   @ParameterizedTest
@@ -538,7 +538,7 @@ class HandleServiceTest {
 
     // Then
     assertThat(result).isEqualTo(expected);
-    then(mongoRepository).should().updateHandleRecords(List.of(expectedDocument));
+    then(mongoRepository).should().updateHandleRecords(List.of(expectedDocument), false);
   }
 
   @Test
@@ -558,7 +558,7 @@ class HandleServiceTest {
 
     // Then
     assertThat(result).isEqualTo(expected);
-    then(mongoRepository).should().updateHandleRecords(List.of(expectedDocument));
+    then(mongoRepository).should().updateHandleRecords(List.of(expectedDocument), false);
   }
 
   @Test


### PR DESCRIPTION
If we are using manual PIDs, and we run out of manual PIDs, we need to do a mongodb upsert, not update. If we have a mix of manual pids and randomly generated ones, then some records will already exist, but others will not. further calls to the api when isUseManualPids = true when there are no more pids in the db will result in all new pids being generated but not inserted into the db. 